### PR TITLE
feat: Add edit mode to show/hide FABs

### DIFF
--- a/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -288,6 +288,7 @@ fun SeatingChartScreen(
     val behaviorTypeNames = remember(behaviorTypes) { behaviorTypes.map { it.name } }
     val showRecentBehavior by settingsViewModel.showRecentBehavior.collectAsState(initial = false)
     var sessionType by remember { mutableStateOf(SessionType.BEHAVIOR) }
+    val editModeEnabled by settingsViewModel.editModeEnabled.collectAsState(initial = false)
 
     Scaffold(
         topBar = {
@@ -480,25 +481,27 @@ fun SeatingChartScreen(
             )
         },
         floatingActionButton = {
-            Column(
-                horizontalAlignment = Alignment.End,
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                FloatingActionButton(
-                    onClick = {
-                        editingStudent = null
-                        showAddEditStudentDialog = true
-                    }
+            if (editModeEnabled) {
+                Column(
+                    horizontalAlignment = Alignment.End,
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    Icon(Icons.Filled.Add, contentDescription = "Add Student")
-                }
-                FloatingActionButton(
-                    onClick = {
-                        editingFurniture = null
-                        showAddEditFurnitureDialog = true
+                    FloatingActionButton(
+                        onClick = {
+                            editingStudent = null
+                            showAddEditStudentDialog = true
+                        }
+                    ) {
+                        Icon(Icons.Filled.Add, contentDescription = "Add Student")
                     }
-                ) {
-                    Icon(Icons.Filled.Add, contentDescription = "Add Furniture")
+                    FloatingActionButton(
+                        onClick = {
+                            editingFurniture = null
+                            showAddEditFurnitureDialog = true
+                        }
+                    ) {
+                        Icon(Icons.Filled.Add, contentDescription = "Add Furniture")
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/myapplication/preferences/AppPreferencesRepository.kt
+++ b/app/src/main/java/com/example/myapplication/preferences/AppPreferencesRepository.kt
@@ -57,6 +57,18 @@ class AppPreferencesRepository(private val context: Context) {
         val GRID_SIZE = intPreferencesKey("grid_size")
         val SHOW_RULERS = booleanPreferencesKey("show_rulers")
         val SHOW_GRID = booleanPreferencesKey("show_grid")
+        val EDIT_MODE_ENABLED = booleanPreferencesKey("edit_mode_enabled")
+    }
+
+    val editModeEnabledFlow: Flow<Boolean> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.EDIT_MODE_ENABLED] ?: false
+        }
+
+    suspend fun updateEditModeEnabled(enabled: Boolean) {
+        context.dataStore.edit { settings ->
+            settings[PreferencesKeys.EDIT_MODE_ENABLED] = enabled
+        }
     }
 
     val recentLogsLimitFlow: Flow<Int> = context.dataStore.data

--- a/app/src/main/java/com/example/myapplication/ui/settings/GeneralSettingsTab.kt
+++ b/app/src/main/java/com/example/myapplication/ui/settings/GeneralSettingsTab.kt
@@ -37,6 +37,7 @@ fun GeneralSettingsTab(
     val gridSize by settingsViewModel.gridSize.collectAsState()
     val showRulers by settingsViewModel.showRulers.collectAsState()
     val showGrid by settingsViewModel.showGrid.collectAsState()
+    val editModeEnabled by settingsViewModel.editModeEnabled.collectAsState()
 
     LazyColumn(
         modifier = Modifier.padding(16.dp),
@@ -172,6 +173,18 @@ fun GeneralSettingsTab(
                 Switch(
                     checked = showGrid,
                     onCheckedChange = { settingsViewModel.updateShowGrid(it) }
+                )
+            }
+        }
+        item {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Enable Edit Mode", modifier = Modifier.weight(1f))
+                Switch(
+                    checked = editModeEnabled,
+                    onCheckedChange = { settingsViewModel.updateEditModeEnabled(it) }
                 )
             }
         }

--- a/app/src/main/java/com/example/myapplication/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/SettingsViewModel.kt
@@ -372,4 +372,13 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             preferencesRepository.updateShowGrid(show)
         }
     }
+
+    val editModeEnabled: StateFlow<Boolean> = preferencesRepository.editModeEnabledFlow
+        .stateIn(viewModelScope, SharingStarted.Lazily, false)
+
+    fun updateEditModeEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            preferencesRepository.updateEditModeEnabled(enabled)
+        }
+    }
 }


### PR DESCRIPTION
This commit introduces an edit mode to control the visibility of the Floating Action Buttons (FABs) for adding students and furniture.

A new 'Enable Edit Mode' switch has been added to the general settings screen. When this mode is enabled, the FABs are visible. When disabled, they are hidden. This behavior is similar to the edit mode in the Python version of the application.

The following changes were made:
- Added `editModeEnabled` preference to `AppPreferencesRepository`.
- Exposed the `editModeEnabled` state in `SettingsViewModel`.
- Added a `Switch` to `GeneralSettingsTab` to control the new setting.
- Updated `MainActivity` to conditionally render the FABs based on the `editModeEnabled` state.