### PR TITLE
feat: Apply student box customizations from dialog and settings

### DIFF
--- a/app/src/main/java/com/example/myapplication/data/Student.kt
+++ b/app/src/main/java/com/example/myapplication/data/Student.kt
@@ -24,6 +24,8 @@ data class Student(
     var customOutlineColor: String? = null,  // e.g., hex string
     var customTextColor: String? = null,      // e.g., hex string
     var customOutlineThickness: Int? = null,
+    var customCornerRadius: Int? = null,
+    var customPadding: Int? = null,
     var customFontFamily: String? = null,
     var customFontSize: Int? = null,
     var customFontColor: String? = null // e.g., in dp

--- a/app/src/main/java/com/example/myapplication/preferences/AppPreferencesRepository.kt
+++ b/app/src/main/java/com/example/myapplication/preferences/AppPreferencesRepository.kt
@@ -17,6 +17,8 @@ const val DEFAULT_STUDENT_BOX_BG_COLOR_HEX = "#FFFFFFFF" // White, recommend ref
 const val DEFAULT_STUDENT_BOX_OUTLINE_COLOR_HEX = "#FF000000" // Black for outline, adjust as needed
 const val DEFAULT_STUDENT_BOX_TEXT_COLOR_HEX = "#FF000000"    // Black for text
 const val DEFAULT_STUDENT_BOX_OUTLINE_THICKNESS_DP = 1 // Default outline thickness in Dp
+const val DEFAULT_STUDENT_BOX_CORNER_RADIUS_DP = 8
+const val DEFAULT_STUDENT_BOX_PADDING_DP = 4
 const val DEFAULT_STUDENT_FONT_FAMILY = "sans-serif" // Android default
 const val DEFAULT_STUDENT_FONT_SIZE_SP = 16 // Example size in SP
 const val DEFAULT_STUDENT_FONT_COLOR_HEX = "#FF000000" // Black
@@ -39,6 +41,8 @@ class AppPreferencesRepository(private val context: Context) {
         val DEFAULT_STUDENT_BOX_OUTLINE_COLOR = stringPreferencesKey("default_student_box_outline_color")
         val DEFAULT_STUDENT_BOX_TEXT_COLOR = stringPreferencesKey("default_student_box_text_color")
         val DEFAULT_STUDENT_BOX_OUTLINE_THICKNESS = intPreferencesKey("default_student_box_outline_thickness")
+        val DEFAULT_STUDENT_BOX_CORNER_RADIUS = intPreferencesKey("default_student_box_corner_radius")
+        val DEFAULT_STUDENT_BOX_PADDING = intPreferencesKey("default_student_box_padding")
 
         val DEFAULT_STUDENT_FONT_FAMILY = stringPreferencesKey("default_student_font_family")
         val DEFAULT_STUDENT_FONT_SIZE = intPreferencesKey("default_student_font_size")
@@ -286,6 +290,28 @@ class AppPreferencesRepository(private val context: Context) {
     suspend fun updateDefaultStudentBoxOutlineThickness(thickness: Int) {
         context.dataStore.edit { settings ->
             settings[PreferencesKeys.DEFAULT_STUDENT_BOX_OUTLINE_THICKNESS] = thickness
+        }
+    }
+
+    val defaultStudentBoxCornerRadiusFlow: Flow<Int> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.DEFAULT_STUDENT_BOX_CORNER_RADIUS] ?: DEFAULT_STUDENT_BOX_CORNER_RADIUS_DP
+        }
+
+    suspend fun updateDefaultStudentBoxCornerRadius(cornerRadius: Int) {
+        context.dataStore.edit { settings ->
+            settings[PreferencesKeys.DEFAULT_STUDENT_BOX_CORNER_RADIUS] = cornerRadius
+        }
+    }
+
+    val defaultStudentBoxPaddingFlow: Flow<Int> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.DEFAULT_STUDENT_BOX_PADDING] ?: DEFAULT_STUDENT_BOX_PADDING_DP
+        }
+
+    suspend fun updateDefaultStudentBoxPadding(padding: Int) {
+        context.dataStore.edit { settings ->
+            settings[PreferencesKeys.DEFAULT_STUDENT_BOX_PADDING] = padding
         }
     }
 

--- a/app/src/main/java/com/example/myapplication/ui/components/StudentDraggableIcon.kt
+++ b/app/src/main/java/com/example/myapplication/ui/components/StudentDraggableIcon.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -166,6 +167,7 @@ fun StudentDraggableIcon(
                                 .heightIn(min = studentUiItem.displayHeight) // Respect minimum height, and expand if content is larger
                         }
                     ),
+                shape = RoundedCornerShape(studentUiItem.displayCornerRadius),
                 colors = CardDefaults.cardColors(containerColor = studentUiItem.displayBackgroundColor),
                 elevation = if (noAnimations) CardDefaults.cardElevation(defaultElevation = 0.dp) else CardDefaults.cardElevation(
                     defaultElevation = 4.dp
@@ -174,7 +176,7 @@ fun StudentDraggableIcon(
                 Box(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier
-                        .padding(8.dp)
+                        .padding(studentUiItem.displayPadding)
                 ) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Text(

--- a/app/src/main/java/com/example/myapplication/ui/dialogs/StudentStyleScreen.kt
+++ b/app/src/main/java/com/example/myapplication/ui/dialogs/StudentStyleScreen.kt
@@ -43,15 +43,17 @@ fun StudentStyleScreen(
     val student by viewModel.student.collectAsState()
 
     // Declare state variables
-    var customBackgroundColor by remember { mutableStateOf("") }
-    var customOutlineColor by remember { mutableStateOf("") }
-    var customTextColor by remember { mutableStateOf("") }
+    val customBackgroundColor = remember { mutableStateOf("") }
+    val customOutlineColor = remember { mutableStateOf("") }
+    val customTextColor = remember { mutableStateOf("") }
     var customWidth by remember { mutableStateOf("") }
     var customHeight by remember { mutableStateOf("") }
+    var customCornerRadius by remember { mutableStateOf("") }
     var customOutlineThickness by remember { mutableStateOf("") }
+    var customPadding by remember { mutableStateOf("") }
     var customFontFamily by remember { mutableStateOf("") }
     var customFontSize by remember { mutableStateOf("") }
-    var customFontColor by remember { mutableStateOf("") }
+    val customFontColor = remember { mutableStateOf("") }
     var expanded by remember { mutableStateOf(false) }
 
     val showColorPicker = remember { mutableStateOf(false) }
@@ -63,15 +65,17 @@ fun StudentStyleScreen(
 
     LaunchedEffect(student) {
         student?.let {
-            customBackgroundColor = it.customBackgroundColor ?: ""
-            customOutlineColor = it.customOutlineColor ?: ""
-            customTextColor = it.customTextColor ?: ""
+            customBackgroundColor.value = it.customBackgroundColor ?: ""
+            customOutlineColor.value = it.customOutlineColor ?: ""
+            customTextColor.value = it.customTextColor ?: ""
             customWidth = it.customWidth?.toString() ?: ""
             customHeight = it.customHeight?.toString() ?: ""
+            customCornerRadius = it.customCornerRadius?.toString() ?: ""
             customOutlineThickness = it.customOutlineThickness?.toString() ?: ""
+            customPadding = it.customPadding?.toString() ?: ""
             customFontFamily = it.customFontFamily ?: ""
             customFontSize = it.customFontSize?.toString() ?: ""
-            customFontColor = it.customFontColor ?: ""
+            customFontColor.value = it.customFontColor ?: ""
         }
     }
 
@@ -93,12 +97,12 @@ fun StudentStyleScreen(
             text = {
                 Column(modifier = Modifier.padding(16.dp)) {
                     TextField(
-                        value = customBackgroundColor,
-                        onValueChange = { customBackgroundColor = it },
+                        value = customBackgroundColor.value,
+                        onValueChange = { customBackgroundColor.value = it },
                         label = { Text("Background Color") },
                         trailingIcon = {
                             Button(onClick = {
-                                colorPickerVar.value = mutableStateOf(customBackgroundColor)
+                                colorPickerVar.value = customBackgroundColor
                                 showColorPicker.value = true
                             }) {
                                 Text("...")
@@ -107,12 +111,12 @@ fun StudentStyleScreen(
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     TextField(
-                        value = customOutlineColor,
-                        onValueChange = { customOutlineColor = it },
+                        value = customOutlineColor.value,
+                        onValueChange = { customOutlineColor.value = it },
                         label = { Text("Outline Color") },
                         trailingIcon = {
                             Button(onClick = {
-                                colorPickerVar.value = mutableStateOf(customOutlineColor)
+                                colorPickerVar.value = customOutlineColor
                                 showColorPicker.value = true
                             }) {
                                 Text("...")
@@ -121,12 +125,12 @@ fun StudentStyleScreen(
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     TextField(
-                        value = customTextColor,
-                        onValueChange = { customTextColor = it },
+                        value = customTextColor.value,
+                        onValueChange = { customTextColor.value = it },
                         label = { Text("Text Color") },
                         trailingIcon = {
                             Button(onClick = {
-                                colorPickerVar.value = mutableStateOf(customTextColor)
+                                colorPickerVar.value = customTextColor
                                 showColorPicker.value = true
                             }) {
                                 Text("...")
@@ -147,9 +151,21 @@ fun StudentStyleScreen(
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     TextField(
+                        value = customCornerRadius,
+                        onValueChange = { customCornerRadius = it },
+                        label = { Text("Corner Radius (dp)") }
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    TextField(
                         value = customOutlineThickness,
                         onValueChange = { customOutlineThickness = it },
                         label = { Text("Outline Thickness (dp)") }
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    TextField(
+                        value = customPadding,
+                        onValueChange = { customPadding = it },
+                        label = { Text("Padding (dp)") }
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     ExposedDropdownMenuBox(
@@ -189,12 +205,12 @@ fun StudentStyleScreen(
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     TextField(
-                        value = customFontColor,
-                        onValueChange = { customFontColor = it },
+                        value = customFontColor.value,
+                        onValueChange = { customFontColor.value = it },
                         label = { Text("Font Color") },
                         trailingIcon = {
                             Button(onClick = {
-                                colorPickerVar.value = mutableStateOf(customFontColor)
+                                colorPickerVar.value = customFontColor
                                 showColorPicker.value = true
                             }) {
                                 Text("...")
@@ -207,15 +223,17 @@ fun StudentStyleScreen(
                 Button(
                     onClick = {
                         val updatedStudent = student!!.copy(
-                            customBackgroundColor = customBackgroundColor.ifBlank { null },
-                            customOutlineColor = customOutlineColor.ifBlank { null },
-                            customTextColor = customTextColor.ifBlank { null },
+                            customBackgroundColor = customBackgroundColor.value.ifBlank { null },
+                            customOutlineColor = customOutlineColor.value.ifBlank { null },
+                            customTextColor = customTextColor.value.ifBlank { null },
                             customWidth = customWidth.toIntOrNull(),
                             customHeight = customHeight.toIntOrNull(),
+                            customCornerRadius = customCornerRadius.toIntOrNull(),
                             customOutlineThickness = customOutlineThickness.toIntOrNull(),
+                            customPadding = customPadding.toIntOrNull(),
                             customFontFamily = customFontFamily.ifBlank { null },
                             customFontSize = customFontSize.toIntOrNull(),
-                            customFontColor = customFontColor.ifBlank { null }
+                            customFontColor = customFontColor.value.ifBlank { null }
                         )
                         viewModel.updateStudent(seatingChartViewModel, updatedStudent)
                         onDismiss()

--- a/app/src/main/java/com/example/myapplication/ui/model/StudentExtensions.kt
+++ b/app/src/main/java/com/example/myapplication/ui/model/StudentExtensions.kt
@@ -8,7 +8,9 @@ import com.example.myapplication.data.Student
 import com.example.myapplication.preferences.DEFAULT_STUDENT_BOX_BG_COLOR_HEX
 import com.example.myapplication.preferences.DEFAULT_STUDENT_BOX_HEIGHT_DP
 import com.example.myapplication.preferences.DEFAULT_STUDENT_BOX_OUTLINE_COLOR_HEX
+import com.example.myapplication.preferences.DEFAULT_STUDENT_BOX_CORNER_RADIUS_DP
 import com.example.myapplication.preferences.DEFAULT_STUDENT_BOX_OUTLINE_THICKNESS_DP
+import com.example.myapplication.preferences.DEFAULT_STUDENT_BOX_PADDING_DP
 import com.example.myapplication.preferences.DEFAULT_STUDENT_BOX_TEXT_COLOR_HEX
 import com.example.myapplication.preferences.DEFAULT_STUDENT_BOX_WIDTH_DP
 
@@ -25,6 +27,8 @@ fun Student.toStudentUiItem(
     defaultOutlineColor: String = DEFAULT_STUDENT_BOX_OUTLINE_COLOR_HEX,
     defaultTextColor: String = DEFAULT_STUDENT_BOX_TEXT_COLOR_HEX,
     defaultOutlineThickness: Int = DEFAULT_STUDENT_BOX_OUTLINE_THICKNESS_DP,
+    defaultCornerRadius: Int = DEFAULT_STUDENT_BOX_CORNER_RADIUS_DP,
+    defaultPadding: Int = DEFAULT_STUDENT_BOX_PADDING_DP,
     defaultFontFamily: String,
     defaultFontSize: Int,
     defaultFontColor: String
@@ -49,6 +53,8 @@ fun Student.toStudentUiItem(
         displayOutlineColor = outlineColor,
         displayTextColor = textColor,
         displayOutlineThickness = (customOutlineThickness ?: defaultOutlineThickness).dp,
+        displayCornerRadius = (customCornerRadius ?: defaultCornerRadius).dp,
+        displayPadding = (customPadding ?: defaultPadding).dp,
         recentBehaviorDescription = recentBehaviorDescription,
         recentHomeworkDescription = recentHomeworkDescription,
         sessionLogText = sessionLogText,

--- a/app/src/main/java/com/example/myapplication/ui/model/StudentUiItem.kt
+++ b/app/src/main/java/com/example/myapplication/ui/model/StudentUiItem.kt
@@ -17,6 +17,8 @@ data class StudentUiItem(
     val displayOutlineColor: Color,
     val displayTextColor: Color,
     val displayOutlineThickness: Dp,
+    val displayCornerRadius: Dp,
+    val displayPadding: Dp,
     val fontFamily: String,
     val fontSize: Int,
     val fontColor: Color,

--- a/app/src/main/java/com/example/myapplication/ui/settings/DisplaySettingsTab.kt
+++ b/app/src/main/java/com/example/myapplication/ui/settings/DisplaySettingsTab.kt
@@ -53,6 +53,8 @@ fun DisplaySettingsTab(
     val defaultOutlineColor by settingsViewModel.defaultStudentBoxOutlineColor.collectAsState()
     val defaultTextColor by settingsViewModel.defaultStudentBoxTextColor.collectAsState()
     val defaultOutlineThickness by settingsViewModel.defaultStudentBoxOutlineThickness.collectAsState()
+    val defaultCornerRadius by settingsViewModel.defaultStudentBoxCornerRadius.collectAsState()
+    val defaultPadding by settingsViewModel.defaultStudentBoxPadding.collectAsState()
 
     var defaultWidthInput by remember(defaultWidth) { mutableStateOf(defaultWidth.toString()) }
     var defaultHeightInput by remember(defaultHeight) { mutableStateOf(defaultHeight.toString()) }
@@ -60,6 +62,8 @@ fun DisplaySettingsTab(
     var defaultOutlineColorInput by remember(defaultOutlineColor) { mutableStateOf(defaultOutlineColor) }
     var defaultTextColorInput by remember(defaultTextColor) { mutableStateOf(defaultTextColor) }
     var defaultOutlineThicknessInput by remember(defaultOutlineThickness) { mutableStateOf(defaultOutlineThickness.toString()) }
+    var defaultCornerRadiusInput by remember(defaultCornerRadius) { mutableStateOf(defaultCornerRadius.toString()) }
+    var defaultPaddingInput by remember(defaultPadding) { mutableStateOf(defaultPadding.toString()) }
 
     LazyColumn(
         modifier = Modifier.padding(16.dp),
@@ -301,6 +305,44 @@ fun DisplaySettingsTab(
                     }
                 },
                 label = { Text("Default Box Outline Thickness (dp)") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        item {
+            Spacer(Modifier.height(8.dp))
+        }
+        item {
+            OutlinedTextField(
+                value = defaultCornerRadiusInput,
+                onValueChange = {
+                    defaultCornerRadiusInput = it
+                    it.toIntOrNull()?.let { value ->
+                        settingsViewModel.updateDefaultStudentBoxCornerRadius(
+                            value.coerceIn(0, 50)
+                        )
+                    }
+                },
+                label = { Text("Default Box Corner Radius (dp)") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        item {
+            Spacer(Modifier.height(8.dp))
+        }
+        item {
+            OutlinedTextField(
+                value = defaultPaddingInput,
+                onValueChange = {
+                    defaultPaddingInput = it
+                    it.toIntOrNull()?.let { value ->
+                        settingsViewModel.updateDefaultStudentBoxPadding(
+                            value.coerceIn(0, 50)
+                        )
+                    }
+                },
+                label = { Text("Default Box Padding (dp)") },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier = Modifier.fillMaxWidth()
             )

--- a/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
@@ -172,6 +172,8 @@ class SeatingChartViewModel(application: Application) : AndroidViewModel(applica
                 appPreferencesRepository.defaultStudentBoxOutlineColorFlow,
                 appPreferencesRepository.defaultStudentBoxTextColorFlow,
                 appPreferencesRepository.defaultStudentBoxOutlineThicknessFlow,
+                appPreferencesRepository.defaultStudentBoxCornerRadiusFlow,
+                appPreferencesRepository.defaultStudentBoxPaddingFlow,
                 appPreferencesRepository.defaultStudentFontFamilyFlow,
                 appPreferencesRepository.defaultStudentFontSizeFlow,
                 appPreferencesRepository.defaultStudentFontColorFlow
@@ -203,6 +205,8 @@ class SeatingChartViewModel(application: Application) : AndroidViewModel(applica
             val defaultOutlineColor = appPreferencesRepository.defaultStudentBoxOutlineColorFlow.first()
             val defaultTextColor = appPreferencesRepository.defaultStudentBoxTextColorFlow.first()
             val defaultOutlineThickness = appPreferencesRepository.defaultStudentBoxOutlineThicknessFlow.first()
+            val defaultCornerRadius = appPreferencesRepository.defaultStudentBoxCornerRadiusFlow.first()
+            val defaultPadding = appPreferencesRepository.defaultStudentBoxPaddingFlow.first()
             val defaultFontFamily = appPreferencesRepository.defaultStudentFontFamilyFlow.first()
             val defaultFontSize = appPreferencesRepository.defaultStudentFontSizeFlow.first()
             val defaultFontColor = appPreferencesRepository.defaultStudentFontColorFlow.first()
@@ -243,6 +247,8 @@ class SeatingChartViewModel(application: Application) : AndroidViewModel(applica
                     defaultOutlineColor = defaultOutlineColor,
                     defaultTextColor = defaultTextColor,
                     defaultOutlineThickness = defaultOutlineThickness,
+                    defaultCornerRadius = defaultCornerRadius,
+                    defaultPadding = defaultPadding,
                     defaultFontFamily = defaultFontFamily,
                     defaultFontSize = defaultFontSize,
                     defaultFontColor = defaultFontColor

--- a/app/src/main/java/com/example/myapplication/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/SettingsViewModel.kt
@@ -17,7 +17,9 @@ import com.example.myapplication.preferences.DEFAULT_STUDENT_BOX_HEIGHT_DP
 import com.example.myapplication.preferences.DEFAULT_STUDENT_BOX_BG_COLOR_HEX
 import com.example.myapplication.preferences.DEFAULT_STUDENT_BOX_OUTLINE_COLOR_HEX
 import com.example.myapplication.preferences.DEFAULT_STUDENT_BOX_TEXT_COLOR_HEX
-import com.example.myapplication.preferences.DEFAULT_STUDENT_BOX_OUTLINE_THICKNESS_DP // Added import
+import com.example.myapplication.preferences.DEFAULT_STUDENT_BOX_OUTLINE_THICKNESS_DP
+import com.example.myapplication.preferences.DEFAULT_STUDENT_BOX_CORNER_RADIUS_DP
+import com.example.myapplication.preferences.DEFAULT_STUDENT_BOX_PADDING_DP
 import com.example.myapplication.utils.SecurityUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
@@ -245,6 +247,24 @@ class SettingsViewModel(
     fun updateDefaultStudentBoxOutlineThickness(thickness: Int) {
         viewModelScope.launch {
             preferencesRepository.updateDefaultStudentBoxOutlineThickness(thickness)
+        }
+    }
+
+    val defaultStudentBoxCornerRadius: StateFlow<Int> = preferencesRepository.defaultStudentBoxCornerRadiusFlow
+        .stateIn(viewModelScope, SharingStarted.Lazily, DEFAULT_STUDENT_BOX_CORNER_RADIUS_DP)
+
+    fun updateDefaultStudentBoxCornerRadius(cornerRadius: Int) {
+        viewModelScope.launch {
+            preferencesRepository.updateDefaultStudentBoxCornerRadius(cornerRadius)
+        }
+    }
+
+    val defaultStudentBoxPadding: StateFlow<Int> = preferencesRepository.defaultStudentBoxPaddingFlow
+        .stateIn(viewModelScope, SharingStarted.Lazily, DEFAULT_STUDENT_BOX_PADDING_DP)
+
+    fun updateDefaultStudentBoxPadding(padding: Int) {
+        viewModelScope.launch {
+            preferencesRepository.updateDefaultStudentBoxPadding(padding)
         }
     }
 


### PR DESCRIPTION
This commit implements the following changes:

- The student style dialog is fixed and now correctly applies all customizations, including corner radius, outline thickness, and padding.
- The color picker logic in the student style dialog is fixed.
- Global default styles for student boxes can now be configured in the settings screen.
- Student icons now use these global defaults, which can be overridden by individual student styles.
- The `Student` data class has been updated to include the new customization fields.