### PR TITLE
Fix student box height and transparency issues

### DIFF
--- a/app/src/main/java/com/example/myapplication/ui/components/StudentDraggableIcon.kt
+++ b/app/src/main/java/com/example/myapplication/ui/components/StudentDraggableIcon.kt
@@ -163,7 +163,7 @@ fun StudentDraggableIcon(
                         } else {
                             Modifier
                                 .width(studentUiItem.displayWidth)
-                                .heightIn(min = studentUiItem.displayHeight)
+                                .heightIn(min = studentUiItem.displayHeight, max = 300.dp)
                         }
                     )
             ) {

--- a/app/src/main/java/com/example/myapplication/ui/model/StudentExtensions.kt
+++ b/app/src/main/java/com/example/myapplication/ui/model/StudentExtensions.kt
@@ -38,9 +38,11 @@ fun Student.toStudentUiItem(
     val baseOutlineColor = customOutlineColor ?: groupColor?.let { safeParseColor(it) } ?: safeParseColor(defaultOutlineColor) ?: Color.Black
 
     val formattedColors = if (conditionalFormattingResult.isNotEmpty()) {
-        conditionalFormattingResult.mapNotNull { it.first?.let { colorStr -> safeParseColor(colorStr) } }
-            .filter { it.alpha > 0 } // Filter out fully transparent colors
-            .map { it.copy(alpha = 1f) }
+        conditionalFormattingResult.mapNotNull {
+            it.first?.let { colorStr -> safeParseColor(colorStr) }
+                ?.takeIf { color -> color.alpha > 0f }
+                ?.copy(alpha = 1f)
+        }
     } else {
         emptyList()
     }

--- a/app/src/main/java/com/example/myapplication/ui/model/StudentExtensions.kt
+++ b/app/src/main/java/com/example/myapplication/ui/model/StudentExtensions.kt
@@ -34,12 +34,13 @@ fun Student.toStudentUiItem(
     val customOutlineColor = customOutlineColor?.let { safeParseColor(it) }
     val customTextColor = customTextColor?.let { safeParseColor(it) }
 
-    val baseBackgroundColor = customBackgroundColor?.let { safeParseColor(it) } ?: safeParseColor(defaultBackgroundColor)
+    val baseBackgroundColor = (customBackgroundColor?.let { safeParseColor(it) } ?: safeParseColor(defaultBackgroundColor)).copy(alpha = 1f)
     val baseOutlineColor = customOutlineColor ?: groupColor?.let { safeParseColor(it) } ?: safeParseColor(defaultOutlineColor) ?: Color.Black
 
     val formattedColors = if (conditionalFormattingResult.isNotEmpty()) {
         conditionalFormattingResult.mapNotNull { it.first?.let { colorStr -> safeParseColor(colorStr) } }
             .filter { it.alpha > 0 } // Filter out fully transparent colors
+            .map { it.copy(alpha = 1f) }
     } else {
         emptyList()
     }


### PR DESCRIPTION
This commit addresses two issues with the student boxes:
1.  The boxes could become extremely tall when auto-expanding. This is now fixed by setting a maximum height of 300.dp.
2.  The boxes could be transparent. This is now fixed by ensuring that all background colors are fully opaque.