### PR TITLE
Fix(student): Correct incident limit and conditional formatting

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,7 +57,6 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    implementation("androidx.compose.material3:material3:1.2.1")
     implementation(kotlin("stdlib"))
     implementation(kotlin("reflect"))
     implementation("androidx.compose.runtime:runtime-livedata")

--- a/app/src/main/java/com/example/myapplication/ui/settings/ConditionalFormattingRuleEditor.kt
+++ b/app/src/main/java/com/example/myapplication/ui/settings/ConditionalFormattingRuleEditor.kt
@@ -23,21 +23,28 @@ fun ConditionalFormattingRuleEditor(
     var ruleType by remember(rule) { mutableStateOf(rule?.type ?: "group") }
     var targetType by remember(rule) { mutableStateOf(rule?.targetType ?: "student") }
     var expanded by remember { mutableStateOf(false) }
+    val gson = Gson()
 
     val conditionState = remember(rule, ruleType) {
-        mutableStateOf(
-            rule?.conditionJson?.let {
-                gson.fromJson<Map<String, Any>>(it, object : TypeToken<Map<String, Any>>() {}.type)
-            } ?: emptyMap()
-        )
+        val initialJson = rule?.conditionJson
+        val type = object : TypeToken<Map<String, Any>>() {}.type
+        val initialMap: Map<String, Any> = if (initialJson != null) {
+            gson.fromJson(initialJson, type)
+        } else {
+            emptyMap()
+        }
+        mutableStateOf(initialMap)
     }
 
     val formatState = remember(rule) {
-        mutableStateOf(
-            rule?.formatJson?.let {
-                Gson().fromJson<Map<String, Any>>(it, object : TypeToken<Map<String, Any>>() {}.type)
-            } ?: emptyMap()
-        )
+        val initialJson = rule?.formatJson
+        val type = object : TypeToken<Map<String, Any>>() {}.type
+        val initialMap: Map<String, Any> = if (initialJson != null) {
+            gson.fromJson(initialJson, type)
+        } else {
+            emptyMap()
+        }
+        mutableStateOf(initialMap)
     }
 
     val ruleTypes = listOf(

--- a/app/src/main/java/com/example/myapplication/util/ConditionalFormattingEngine.kt
+++ b/app/src/main/java/com/example/myapplication/util/ConditionalFormattingEngine.kt
@@ -129,10 +129,20 @@ object ConditionalFormattingEngine {
                     val days = activeTime.daysOfWeek
 
                     // Python: Monday is 0 and Sunday is 6
-                    // Java: Sunday is 1 and Saturday is 7
-                    val javaDayOfWeek = if (dayOfWeek == 1) 6 else dayOfWeek - 2
+                    // Java: Sunday is 1, Monday is 2, ..., Saturday is 7
+                    // We need to map Java's Day of week to Python's
+                    val pythonDayOfWeek = when (now.get(java.util.Calendar.DAY_OF_WEEK)) {
+                        java.util.Calendar.MONDAY -> 0
+                        java.util.Calendar.TUESDAY -> 1
+                        java.util.Calendar.WEDNESDAY -> 2
+                        java.util.Calendar.THURSDAY -> 3
+                        java.util.Calendar.FRIDAY -> 4
+                        java.util.Calendar.SATURDAY -> 5
+                        java.util.Calendar.SUNDAY -> 6
+                        else -> -1 // Should not happen
+                    }
 
-                    currentTime in start..end && javaDayOfWeek in days
+                    currentTime in start..end && pythonDayOfWeek in days
                 }
 
                 if (!isTimeValid) {

--- a/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
@@ -252,9 +252,9 @@ class SeatingChartViewModel @Inject constructor(
                     } else {
                         it.type
                     }
-                }.take(maxLogsToDisplay)
+                }
 
-                val homeworkDescription = recentHomework.map { it.assignmentName }.take(maxLogsToDisplay)
+                val homeworkDescription = recentHomework.map { it.assignmentName }
 
                 val sessionLogs = if (isSessionActive.value == true) {
                     val quizLogs = sessionQuizLogs.value?.filter { it.studentId == student.id }?.map { "Quiz: ${it.comment}" } ?: emptyList()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,6 @@ hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 androidx-startup-runtime = { group = "androidx.startup", name = "startup-runtime", version.ref = "startupRuntime" }
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleViewmodelKtx" }
-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This commit addresses two issues:

1.  The number of recent incidents displayed on student boxes was hardcoded to 1, ignoring the user's setting. This was caused by an extra `.take(maxLogsToDisplay)` call in the `SeatingChartViewModel`. This has been removed, so the number of incidents is now correctly controlled by the `recentBehaviorIncidentsLimit` setting.

2.  The conditional formatting was not working due to an incorrect day-of-the-week conversion in the `ConditionalFormattingEngine`. The logic has been corrected to properly map Java's `Calendar` days to the Python-style days used in the formatting rules.

Additionally, this commit includes minor refactoring in the `ConditionalFormattingRuleEditor` to fix compilation errors and cleans up unused dependencies.