### PR TITLE
🛡️ Shield: Security Hardening in SecurityUtil and Exporter

### DIFF
--- a/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -60,7 +60,6 @@ class MainActivity : ComponentActivity() {
             seatingChartViewModel.pendingExportOptions?.let { options ->
                 lifecycleScope.launch {
                     val result = seatingChartViewModel.exportData(
-                        context = this@MainActivity,
                         uri = it,
                         options = options
                     )
@@ -754,7 +753,6 @@ fun SeatingChartScreen(
                             val uri = Uri.fromFile(file)
                             seatingChartViewModel.pendingExportOptions?.let { options ->
                                 val result = seatingChartViewModel.exportData(
-                                    context = activity,
                                     uri = uri,
                                     options = options
                                 )

--- a/app/src/main/java/com/example/myapplication/data/exporter/Exporter.kt
+++ b/app/src/main/java/com/example/myapplication/data/exporter/Exporter.kt
@@ -22,18 +22,20 @@ import java.io.FileOutputStream
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
 
 /**
  * Handles the generation of Excel (.xlsx) reports from application data.
  * Supports filtering by date, students, and log types, and can optionally encrypt the output.
  *
  * @param context The application context, used for accessing files and content resolver.
+ * @param securityUtil The security utility for encryption/decryption.
  */
-class Exporter(
-    private val context: Context
+class Exporter @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val securityUtil: SecurityUtil
 ) {
-
-    private val securityUtil = SecurityUtil(context)
 
     /**
      * Exports students, behavior events, homework logs, and quiz logs to an Excel file.
@@ -138,7 +140,7 @@ class Exporter(
         context.contentResolver.openFileDescriptor(uri, "w")?.use {
             FileOutputStream(it.fileDescriptor).use { outputStream ->
                 if (encrypt) {
-                    val encryptedToken = securityUtil.encrypt(String(fileContent))
+                    val encryptedToken = securityUtil.encrypt(fileContent)
                     outputStream.write(encryptedToken.toByteArray(Charsets.UTF_8))
                 } else {
                     outputStream.write(fileContent)

--- a/app/src/main/java/com/example/myapplication/util/EmailWorker.kt
+++ b/app/src/main/java/com/example/myapplication/util/EmailWorker.kt
@@ -38,10 +38,9 @@ class EmailWorker(
         val customHomeworkStatusDao = db.customHomeworkStatusDao()
         val pendingEmailDao = db.pendingEmailDao()
 
-        val exporter = Exporter(applicationContext)
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
-
         val securityUtil = SecurityUtil(applicationContext)
+        val exporter = Exporter(applicationContext, securityUtil)
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
         val preferencesRepository = AppPreferencesRepository(applicationContext, securityUtil)
         val from = preferencesRepository.defaultEmailAddressFlow.first()
         val password = preferencesRepository.emailPasswordFlow.first()

--- a/app/src/main/java/com/example/myapplication/util/EncryptedFileHandler.kt
+++ b/app/src/main/java/com/example/myapplication/util/EncryptedFileHandler.kt
@@ -9,12 +9,11 @@ import javax.inject.Inject
 
 /**
  * Handles reading and writing encrypted files, with a graceful fallback to plaintext.
+ * Use this for text-based files like JSON data.
  */
 class EncryptedFileHandler @Inject constructor(
-    @ApplicationContext context: Context
+    private val securityUtil: SecurityUtil
 ) {
-
-    private val securityUtil = SecurityUtil(context)
 
     /**
      * Reads a file, attempts to decrypt it, and returns the content as a string.
@@ -34,6 +33,7 @@ class EncryptedFileHandler @Inject constructor(
 
         // Try to decrypt first
         return try {
+            // We expect the file to contain a URL-safe Base64 Fernet token (which is a string)
             securityUtil.decrypt(String(fileContentBytes, StandardCharsets.UTF_8))
         } catch (e: SecurityException) {
             // If decryption fails, assume it's plaintext

--- a/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
@@ -107,7 +107,8 @@ class SeatingChartViewModel @Inject constructor(
     private val customHomeworkTypeDao: CustomHomeworkTypeDao,
     private val systemBehaviorDao: SystemBehaviorDao,
     private val appPreferencesRepository: AppPreferencesRepository,
-    private val application: Application
+    private val application: Application,
+    private val exporter: com.example.myapplication.data.exporter.Exporter
 ) : ViewModel() {
 
     val allStudents: LiveData<List<Student>>
@@ -536,7 +537,6 @@ class SeatingChartViewModel @Inject constructor(
     }
 
     suspend fun exportData(
-        context: Context,
         uri: Uri,
         options: com.example.myapplication.data.exporter.ExportOptions
     ): Result<Unit> = withContext(Dispatchers.IO) {
@@ -546,10 +546,9 @@ class SeatingChartViewModel @Inject constructor(
         val quizLogs = quizLogDao.getAllQuizLogsList()
         val studentGroups = studentGroupDao.getAllStudentGroupsList()
         val quizMarkTypes = quizMarkTypeDao.getAllQuizMarkTypesList()
-        val customHomeworkTypes = AppDatabase.getDatabase(context).customHomeworkTypeDao().getAllCustomHomeworkTypesList()
-        val customHomeworkStatuses = AppDatabase.getDatabase(context).customHomeworkStatusDao().getAllCustomHomeworkStatusesList()
+        val customHomeworkTypes = customHomeworkTypeDao.getAllCustomHomeworkTypesList()
+        val customHomeworkStatuses = customHomeworkStatusDao.getAllCustomHomeworkStatusesList()
 
-        val exporter = com.example.myapplication.data.exporter.Exporter(context)
         exporter.export(
             uri = uri,
             options = options,

--- a/app/src/test/java/com/example/myapplication/data/exporter/ExporterTest.kt
+++ b/app/src/test/java/com/example/myapplication/data/exporter/ExporterTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.net.Uri
 import android.os.ParcelFileDescriptor
 import com.example.myapplication.data.*
+import com.example.myapplication.util.SecurityUtil
 import io.mockk.every
 import io.mockk.mockk
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
@@ -37,7 +38,8 @@ class ExporterTest {
         every { pfd.fileDescriptor } returns fos.fd
         every { contentResolver.openFileDescriptor(uri, "w") } returns pfd
 
-        val exporter = Exporter(context)
+        val securityUtil = SecurityUtil(context)
+        val exporter = Exporter(context, securityUtil)
 
         val students = listOf(Student(id = 1, firstName = "John", lastName = "Doe", stringId = "1"))
         val behaviorEvents = listOf(BehaviorEvent(id = 1, studentId = 1, type = "Participation", timestamp = System.currentTimeMillis(), comment = "test comment"))
@@ -127,7 +129,8 @@ class ExporterTest {
         every { pfd.fileDescriptor } returns fos.fd
         every { contentResolver.openFileDescriptor(uri, "w") } returns pfd
 
-        val exporter = Exporter(context)
+        val securityUtil = SecurityUtil(context)
+        val exporter = Exporter(context, securityUtil)
 
         val students = listOf(Student(id = 1, firstName = "John", lastName = "Doe", stringId = "1"))
         val quizLogs = listOf(QuizLog(id = 1, studentId = 1, quizName = "Math Quiz", markValue = 10.0, maxMarkValue = 10.0, loggedAt = System.currentTimeMillis(), comment = null, marksData = "{}", numQuestions = 10, markType = "pts"))


### PR DESCRIPTION
### **User description**
### 🛡️ Shield: Security Hardening in SecurityUtil and Exporter

#### 🔓 The Vulnerability:
1.  **Integer Overflow:** In `SecurityUtil.kt`, the `TTL_SECONDS` constant (representing 100 years) was calculated using 32-bit signed integers, resulting in an overflow to a negative value. This caused Fernet tokens to potentially be treated as expired or invalid immediately.
2.  **Data Integrity/Corruption:** The `Exporter` was converting binary Excel files to `String` (UTF-8) before encryption. Since binary data often contains sequences that are invalid in UTF-8, this led to silent data corruption during the encryption process.

#### 🔐 The Fix:
1.  **Overflow Fix:** Changed `TTL_SECONDS` to a `Long` and updated `FernetCipher` to support 64-bit TTL values.
2.  **Binary-Safe Encryption:** Implemented `encrypt(ByteArray)` and `decryptToByteArray(String)` in `SecurityUtil` and updated `Exporter` to use these methods, bypassing risky string conversions.
3.  **Hilt Integration:** Refactored `Exporter` and `EncryptedFileHandler` to use the Hilt-injected `SecurityUtil` singleton, improving consistency and testability.
4.  **Narrower Error Handling:** Refactored the decryption fallback mechanism to only trigger on `SecurityException` (likely key mismatch) rather than any generic error.

#### 📜 Compliance:
This hardening aligns with OWASP Mobile Security Testing Guide (MSTG) recommendations for proper cryptographic implementation and data integrity protection. By using device-specific keys with a secure fallback and ensuring binary data is handled correctly, we strengthen the app's overall security posture without breaking existing user workflows.

---
*PR created automatically by Jules for task [2084194268947291307](https://jules.google.com/task/2084194268947291307) started by @YMSeatt*


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed integer overflow in TTL_SECONDS by converting to Long type

- Added binary-safe encryption methods to prevent data corruption

- Refactored Exporter and EncryptedFileHandler to use Hilt injection

- Narrowed exception handling to only catch SecurityException in decryption fallback

- Removed unused context parameter from exportData method


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TTL Integer Overflow"] -->|"Convert to Long"| B["SecurityUtil.kt"]
  C["Binary Data Corruption"] -->|"Add ByteArray methods"| B
  D["Manual Instantiation"] -->|"Use Hilt Injection"| E["Exporter & EncryptedFileHandler"]
  F["Broad Exception Handling"] -->|"Catch SecurityException only"| G["Decryption Fallback"]
  B --> H["Enhanced Security"]
  E --> H
  G --> H
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SecurityUtil.kt</strong><dd><code>Fix TTL overflow and add binary encryption support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/com/example/myapplication/util/SecurityUtil.kt

<ul><li>Fixed TTL_SECONDS integer overflow by using Long literal (60L instead <br>of 60)<br> <li> Added overloaded encrypt(ByteArray) method for binary-safe encryption<br> <li> Added decryptToByteArray(String) method to return raw bytes instead of <br>string<br> <li> Updated decrypt(String) to use decryptToByteArray internally<br> <li> Changed FernetCipher.decrypt() parameter from Int to Long for TTL<br> <li> Narrowed exception handling to only catch SecurityException in <br>fallback logic</ul>


</details>


  </td>
  <td><a href="https://github.com/YMSeatt/JaffeAndroid/pull/177/files#diff-ab4dc24c0ebe46d8e7c25b186e6c279fc8c734c522920e504fab4d1283fcffe2">+28/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Exporter.kt</strong><dd><code>Refactor to Hilt injection and binary encryption</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/com/example/myapplication/data/exporter/Exporter.kt

<ul><li>Refactored to use Hilt dependency injection with @Inject constructor<br> <li> Changed to accept SecurityUtil as constructor parameter instead of <br>creating locally<br> <li> Updated encrypt call to use binary-safe encrypt(ByteArray) method<br> <li> Added @ApplicationContext annotation for context injection<br> <li> Updated class documentation to reflect SecurityUtil dependency</ul>


</details>


  </td>
  <td><a href="https://github.com/YMSeatt/JaffeAndroid/pull/177/files#diff-3e04be05ccb471bffe9ae9eeed93cc5f0638ab597a91841426002eee7f094fa5">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EncryptedFileHandler.kt</strong><dd><code>Refactor to Hilt injection for SecurityUtil</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/com/example/myapplication/util/EncryptedFileHandler.kt

<ul><li>Refactored to accept SecurityUtil as constructor parameter via Hilt <br>injection<br> <li> Removed local SecurityUtil instantiation<br> <li> Added clarifying comment that this handler is for text-based files<br> <li> Improved exception handling to only catch SecurityException</ul>


</details>


  </td>
  <td><a href="https://github.com/YMSeatt/JaffeAndroid/pull/177/files#diff-ba89ae3d3e093da088406f1a55009e825d7aa43b1692b455f73f472f836f041e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SeatingChartViewModel.kt</strong><dd><code>Remove context parameter and use injected Exporter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt

<ul><li>Added Exporter as injected dependency in constructor<br> <li> Removed context parameter from exportData method signature<br> <li> Removed local Exporter instantiation inside exportData<br> <li> Replaced AppDatabase.getDatabase(context) calls with injected DAO <br>references</ul>


</details>


  </td>
  <td><a href="https://github.com/YMSeatt/JaffeAndroid/pull/177/files#diff-d55ea31a68f6d83abf8a71181f6c02ae42634e2b28f3d26267d3a9b843215aea">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MainActivity.kt</strong><dd><code>Remove context parameter from exportData calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/com/example/myapplication/MainActivity.kt

<ul><li>Removed context parameter from exportData method calls in two <br>locations<br> <li> Updated both createDocumentLauncher and SeatingChartScreen to match <br>new method signature</ul>


</details>


  </td>
  <td><a href="https://github.com/YMSeatt/JaffeAndroid/pull/177/files#diff-012b399eb9c6b6b9244f7f269777cebd04fc27217bbd730136baf5e5aed67983">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EmailWorker.kt</strong><dd><code>Update Exporter instantiation with SecurityUtil</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/com/example/myapplication/util/EmailWorker.kt

<ul><li>Reordered instantiation to create SecurityUtil before Exporter<br> <li> Updated Exporter instantiation to pass SecurityUtil as parameter<br> <li> Removed redundant local variable assignments</ul>


</details>


  </td>
  <td><a href="https://github.com/YMSeatt/JaffeAndroid/pull/177/files#diff-ff73f2f4882275f1d1ff4e24117036660e6a9eeb9b1f1e23ff64edae17b1f16e">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ExporterTest.kt</strong><dd><code>Update test setup for Exporter dependency injection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/test/java/com/example/myapplication/data/exporter/ExporterTest.kt

<ul><li>Added SecurityUtil import<br> <li> Updated Exporter instantiation in two test methods to pass <br>SecurityUtil parameter<br> <li> Created SecurityUtil instance before creating Exporter in tests</ul>


</details>


  </td>
  <td><a href="https://github.com/YMSeatt/JaffeAndroid/pull/177/files#diff-a96e14610ca945f2356e458e8093856090571581653e931b96d26338298f413a">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

