### PR TITLE
🛡️ Shield: Universal Database Size Limits and Share Hardening

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -84,3 +84,10 @@
     - Transitioned to an **ID-Only Intent Protocol**. Alarms now only carry the `reminder_id`.
     - `ReminderReceiver` fetches and decrypts the PII from the secure database only when the alarm triggers.
 - **Location:** `app/src/main/java/com/example/myapplication/util/ReminderManager.kt`, `app/src/main/java/com/example/myapplication/util/ReminderReceiver.kt`
+
+## 🛡️ Privacy and Reliability Hardening: Universal Database Size Limits
+- **Vulnerability:** Size limits (50MB) for database operations were only enforced for encrypted files, leaving the app vulnerable to OOM/DoS attacks via large plaintext database backups, shares, or restores. Additionally, `shareDatabase` used a static filename, creating a risk of race conditions and data corruption.
+- **Fix:**
+    - Implemented a mandatory 50MB size limit for **all** database operations (backup, share, restore) regardless of encryption status.
+    - Hardened `shareDatabase` to use unique, timestamp-based filenames to prevent collisions in the shared cache.
+- **Location:** `app/src/main/java/com/example/myapplication/viewmodel/SettingsViewModel.kt`

--- a/app/src/main/java/com/example/myapplication/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/SettingsViewModel.kt
@@ -91,6 +91,15 @@ class SettingsViewModel @Inject constructor(
     private val securityUtil: SecurityUtil
 ) : ViewModel() {
 
+    companion object {
+        /**
+         * Mandatory security boundary for database file operations.
+         * Enforcing a 50MB limit prevents Out-of-Memory (OOM) attacks during decryption
+         * and Denial-of-Service (DoS) via storage exhaustion.
+         */
+        private const val MAX_DB_SIZE_BYTES = 50 * 1024 * 1024L
+    }
+
     private val _restoreComplete = MutableLiveData<Boolean>()
     val restoreComplete: LiveData<Boolean> = _restoreComplete
 
@@ -630,16 +639,15 @@ class SettingsViewModel @Inject constructor(
         val dbFile = application.getDatabasePath(AppDatabase.DATABASE_NAME)
         if (!dbFile.exists()) return@withContext
 
+        // HARDEN: Universal limit to prevent DoS/OOM regardless of encryption status
+        if (dbFile.length() > MAX_DB_SIZE_BYTES) {
+            Log.e("SettingsViewModel", "Backup failed: Database exceeds 50MB limit.")
+            return@withContext
+        }
+
         val encrypt = preferencesRepository.encryptDataFilesFlow.first()
         application.contentResolver.openOutputStream(uri)?.use { outputStream ->
             if (encrypt) {
-                // HARDEN: Check database size before reading for encryption to prevent OOM
-                val maxSizeBytes = 50 * 1024 * 1024L
-                if (dbFile.length() > maxSizeBytes) {
-                    Log.e("SettingsViewModel", "Backup failed: Database exceeds 50MB limit for encryption.")
-                    return@withContext
-                }
-
                 // Encryption requires the full payload for the Fernet token
                 val dbBytes = FileInputStream(dbFile).use { it.readBytes() }
                 val encryptedToken = securityUtil.encrypt(dbBytes)
@@ -663,7 +671,6 @@ class SettingsViewModel @Inject constructor(
      * 3. Only signals success to the UI if the restoration truly succeeds.
      */
     suspend fun restoreDatabase(uri: Uri) = withContext(Dispatchers.IO) {
-        val maxSizeBytes = 50 * 1024 * 1024 // 50MB limit
         val dbFile = application.getDatabasePath(AppDatabase.DATABASE_NAME)
 
         // Close existing connections and clear temporary journal files before overwriting
@@ -694,7 +701,7 @@ class SettingsViewModel @Inject constructor(
                     var totalRead = 6L
                     while (inputStream.read(buffer).also { read = it } != -1) {
                         totalRead += read
-                        if (totalRead > maxSizeBytes) {
+                        if (totalRead > MAX_DB_SIZE_BYTES) {
                             Log.e("SettingsViewModel", "Restore failed: Encrypted file exceeds 50MB limit.")
                             return@withContext
                         }
@@ -722,7 +729,7 @@ class SettingsViewModel @Inject constructor(
                         var totalRead = if (prefixRead > 0) prefixRead.toLong() else 0L
                         while (inputStream.read(buffer).also { read = it } != -1) {
                             totalRead += read
-                            if (totalRead > maxSizeBytes) {
+                            if (totalRead > MAX_DB_SIZE_BYTES) {
                                 Log.e("SettingsViewModel", "Restore failed: Database file exceeds 50MB limit.")
                                 outputStream.close()
                                 dbFile.delete()
@@ -904,20 +911,28 @@ class SettingsViewModel @Inject constructor(
      */
     suspend fun shareDatabase(): Uri? = withContext(Dispatchers.IO) {
         val dbFile = application.getDatabasePath(AppDatabase.DATABASE_NAME)
+        if (!dbFile.exists()) return@withContext null
+
+        // HARDEN: Universal limit to prevent DoS/OOM regardless of encryption status
+        if (dbFile.length() > MAX_DB_SIZE_BYTES) {
+            Log.e("SettingsViewModel", "Share failed: Database exceeds 50MB limit.")
+            return@withContext null
+        }
+
         val sharedDir = java.io.File(application.cacheDir, "shared")
         if (!sharedDir.exists()) sharedDir.mkdirs()
-        val sharedDbFile = java.io.File(sharedDir, "seating_chart_database.db")
+
+        // HARDEN: Clean up previous database shares to prevent storage leaks in cache
+        sharedDir.listFiles { _, name -> name.startsWith("seating_chart_database_") && name.endsWith(".db") }
+            ?.forEach { it.delete() }
+
+        // HARDEN: Use unique filenames to prevent collisions and potential data corruption
+        val filename = "seating_chart_database_${System.currentTimeMillis()}.db"
+        val sharedDbFile = java.io.File(sharedDir, filename)
 
         val encrypt = preferencesRepository.encryptDataFilesFlow.first()
 
         if (encrypt) {
-            // HARDEN: Check database size before reading for encryption to prevent OOM
-            val maxSizeBytes = 50 * 1024 * 1024L
-            if (dbFile.length() > maxSizeBytes) {
-                Log.e("SettingsViewModel", "Share failed: Database exceeds 50MB limit for encryption.")
-                return@withContext null
-            }
-
             // Encryption requires the full payload for the Fernet token
             val dbBytes = FileInputStream(dbFile).use { it.readBytes() }
             val encryptedToken = securityUtil.encrypt(dbBytes)


### PR DESCRIPTION
🔓 *The Vulnerability:* The application enforced a 50MB size limit for encrypted database backups and restores, but plaintext operations were unhardened. This left the app vulnerable to Out-of-Memory (OOM) and Denial-of-Service (DoS) attacks via oversized database files. Additionally, `shareDatabase` used a static filename, creating race conditions and potential data corruption.

🔐 *The Fix:*
- Implemented `MAX_DB_SIZE_BYTES` (50MB) as a universal security boundary in `SettingsViewModel.kt`.
- Hardened `backupDatabase`, `restoreDatabase`, and `shareDatabase` to strictly enforce this limit regardless of encryption status.
- Implemented a "Clean-on-Share" policy in `shareDatabase` that purges old shared exports and uses unique, timestamped filenames to prevent collisions and storage leaks in the cache.

📜 *Compliance:* This hardening aligns with OWASP Mobile Security standards for preventing DoS and ensuring safe inter-process communication (IPC) via shared files.

---
*PR created automatically by Jules for task [7660457626137143738](https://jules.google.com/task/7660457626137143738) started by @YMSeatt*