### PR TITLE
🛡️ Shield: Security Hardening in Seating Chart and Settings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,8 @@
     <application
         android:name=".MyApplication"
         android:allowBackup="false"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:extractNativeLibs="false"
         android:networkSecurityConfig="@xml/network_security_config"
         android:enableOnBackInvokedCallback="true"

--- a/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
+++ b/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
@@ -1698,9 +1698,8 @@ fun SeatingChartScreen(
                             }
                             "NEURAL_DOSSIER" -> {
                                 selectedStudentUiItemForAction?.let { student ->
-                                    val report = GhostLinkEngine.generateNeuralDossier(student.id.toLong(), student.fullName.value)
+                                    GhostLinkEngine.generateNeuralDossier(student.id.toLong(), student.fullName.value)
                                     Toast.makeText(context, "Neural Dossier Generated for ${student.fullName.value}", Toast.LENGTH_SHORT).show()
-                                    Log.d("GhostLink", report)
                                 }
                             }
                             "EDIT_STUDENT" -> {

--- a/app/src/main/java/com/example/myapplication/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/SettingsViewModel.kt
@@ -650,8 +650,12 @@ class SettingsViewModel @Inject constructor(
             if (encrypt) {
                 // Encryption requires the full payload for the Fernet token
                 val dbBytes = FileInputStream(dbFile).use { it.readBytes() }
-                val encryptedToken = securityUtil.encrypt(dbBytes)
-                outputStream.write(encryptedToken.toByteArray(Charsets.UTF_8))
+                try {
+                    val encryptedToken = securityUtil.encrypt(dbBytes)
+                    outputStream.write(encryptedToken.toByteArray(Charsets.UTF_8))
+                } finally {
+                    dbBytes.fill(0.toByte())
+                }
             } else {
                 // Stream the file directly to avoid OOM for large databases
                 FileInputStream(dbFile).use { inputStream ->
@@ -935,8 +939,12 @@ class SettingsViewModel @Inject constructor(
         if (encrypt) {
             // Encryption requires the full payload for the Fernet token
             val dbBytes = FileInputStream(dbFile).use { it.readBytes() }
-            val encryptedToken = securityUtil.encrypt(dbBytes)
-            sharedDbFile.writeText(encryptedToken)
+            try {
+                val encryptedToken = securityUtil.encrypt(dbBytes)
+                sharedDbFile.writeText(encryptedToken)
+            } finally {
+                dbBytes.fill(0.toByte())
+            }
         } else {
             // HARDEN: Stream the file directly to avoid OOM for large databases
             FileInputStream(dbFile).use { inputStream ->

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="file" path="fernet.key" />
+    <exclude domain="file" path="fernet.key.v2" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="file" path="fernet.key" />
+        <exclude domain="file" path="fernet.key.v2" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="file" path="fernet.key" />
+        <exclude domain="file" path="fernet.key.v2" />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
🔓 *The Vulnerability:* 
1. Sensitive student "Neural Dossiers" (PII) were being leaked to system logs via `Log.d` in the seating chart screen. 
2. Plaintext database contents remained in memory as `ByteArray` objects after backup and sharing operations. 
3. Sensitive encryption keys (`fernet.key`, `fernet.key.v2`) were not explicitly excluded from Android's auto-backup and device-to-device transfer systems. 
 
🔐 *The Fix:* 
1. Removed insecure `Log.d` calls in `SeatingChartScreen.kt` and cleaned up unused dossier generation variables. 
2. Implemented `try-finally` blocks in `SettingsViewModel.kt` to explicitly clear sensitive byte arrays using `.fill(0.toByte())` immediately after use. 
3. Created `backup_rules.xml` and `data_extraction_rules.xml` to exclude encryption keys and referenced them in the `AndroidManifest.xml` for defense-in-depth protection. 
 
📜 *Compliance:* This aligns with OWASP MASVS (Mobile Application Security Verification Standard) guidelines regarding PII protection, secure memory management, and data at rest security.

---
*PR created automatically by Jules for task [2968925799256490862](https://jules.google.com/task/2968925799256490862) started by @YMSeatt*