### PR TITLE
Ghost Relay: Integrated Neural Dossier Sharing

### DIFF
--- a/.jules/ghost_todo.md
+++ b/.jules/ghost_todo.md
@@ -1,10 +1,10 @@
 # 👻 Ghost Android Backlog
 - [ ] Idea: "Ghost Memento" - Persistent Undo/Redo across app restarts using DataStore.
-- [ ] Idea: "Ghost Relay" - Integrated Android Share Sheet for Neural Dossiers.
 
 ## 🚧 Active Construction
 
 ## ✅ Completed Enhancements
+- [DONE] 2028-04-06: Ghost Relay - Integrated Android Share Sheet for Neural Dossiers in `SeatingChartScreen.kt`
 - [DONE] 2028-04-05: Ghost Student Hub - Per-student radial quick-action menu in `/labs/ghost/hub/GhostStudentHubLayer.kt`
 - [DONE] 2028-04-01: Ghost Chroma - Material You & Neural Theme Engine in `/labs/ghost/util/GhostChroma.kt`
 - [DONE] 2028-03-28: Ghost Adaptive UI - Density-aware seating chart layouts in `/labs/ghost/adaptive`

--- a/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
+++ b/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
@@ -1698,8 +1698,13 @@ fun SeatingChartScreen(
                             }
                             "NEURAL_DOSSIER" -> {
                                 selectedStudentUiItemForAction?.let { student ->
-                                    GhostLinkEngine.generateNeuralDossier(student.id.toLong(), student.fullName.value)
-                                    Toast.makeText(context, "Neural Dossier Generated for ${student.fullName.value}", Toast.LENGTH_SHORT).show()
+                                    val dossier = GhostLinkEngine.generateNeuralDossier(student.id.toLong(), student.fullName.value)
+                                    val intent = Intent(Intent.ACTION_SEND).apply {
+                                        type = "text/plain"
+                                        putExtra(Intent.EXTRA_SUBJECT, "Neural Dossier: ${student.fullName.value}")
+                                        putExtra(Intent.EXTRA_TEXT, dossier)
+                                    }
+                                    context.startActivity(Intent.createChooser(intent, "Share Neural Dossier"))
                                 }
                             }
                             "EDIT_STUDENT" -> {


### PR DESCRIPTION
The 'Ghost Relay' enhancement integrates the native Android Share Sheet for sharing 'Neural Dossiers' generated by `GhostLinkEngine`. When a user selects the 'Neural Dossier' action from the student radial hub, the app now launches a chooser allowing the Markdown-formatted report to be shared via any compatible text-handling application.

---
*PR created automatically by Jules for task [2248659168283930793](https://jules.google.com/task/2248659168283930793) started by @YMSeatt*