### PR TITLE
🛡️ Shield: Privacy Hardening for Neural Dossiers

### DIFF
--- a/app/src/main/java/com/example/myapplication/labs/ghost/GhostLinkEngine.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/GhostLinkEngine.kt
@@ -45,10 +45,18 @@ object GhostLinkEngine {
             "Phase 3: Predicting Academic Synergy with neighboring nodes."
         )
 
+        // PRIVACY: Mask the student name in the report content (e.g., "John Doe" -> "J. DOE")
+        val nameParts = studentName.trim().split(" ")
+        val maskedName = if (nameParts.size >= 2) {
+            "${nameParts.first().take(1)}. ${nameParts.last()}"
+        } else {
+            studentName
+        }.uppercase(Locale.US)
+
         val report = StringBuilder()
-        report.append("# \uD83D\uDC7B GHOST NEURAL DOSSIER: ${studentName.uppercase(Locale.US)}\n")
+        report.append("# \uD83D\uDC7B GHOST NEURAL DOSSIER: $maskedName\n")
         report.append("**Status:** Teleported via Ghost Portal\n")
-        report.append("**Internal ID:** $studentId\n")
+        // PRIVACY: Removed Internal ID to prevent leaking database state
         report.append("**Analysis Timestamp:** $timestamp\n\n")
         report.append("---\n\n")
 

--- a/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
+++ b/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
@@ -1698,10 +1698,20 @@ fun SeatingChartScreen(
                             }
                             "NEURAL_DOSSIER" -> {
                                 selectedStudentUiItemForAction?.let { student ->
-                                    val dossier = GhostLinkEngine.generateNeuralDossier(student.id.toLong(), student.fullName.value)
+                                    val fullName = student.fullName.value
+                                    val dossier = GhostLinkEngine.generateNeuralDossier(student.id.toLong(), fullName)
+
+                                    // PRIVACY: Mask the student name in the intent subject (e.g., "J. DOE")
+                                    val nameParts = fullName.trim().split(" ")
+                                    val maskedName = if (nameParts.size >= 2) {
+                                        "${nameParts.first().take(1)}. ${nameParts.last()}"
+                                    } else {
+                                        fullName
+                                    }.uppercase(java.util.Locale.US)
+
                                     val intent = Intent(Intent.ACTION_SEND).apply {
                                         type = "text/plain"
-                                        putExtra(Intent.EXTRA_SUBJECT, "Neural Dossier: ${student.fullName.value}")
+                                        putExtra(Intent.EXTRA_SUBJECT, "Neural Dossier: $maskedName")
                                         putExtra(Intent.EXTRA_TEXT, dossier)
                                     }
                                     context.startActivity(Intent.createChooser(intent, "Share Neural Dossier"))

--- a/app/src/test/java/com/example/myapplication/labs/ghost/GhostLinkEngineTest.kt
+++ b/app/src/test/java/com/example/myapplication/labs/ghost/GhostLinkEngineTest.kt
@@ -11,9 +11,10 @@ class GhostLinkEngineTest {
         val studentName = "John Doe"
         val dossier = GhostLinkEngine.generateNeuralDossier(studentId, studentName)
 
-        // Asserting on smaller chunks to see what exactly fails
-        assertThat(dossier).contains("123")
-        assertThat(dossier).contains("JOHN DOE")
+        // PRIVACY HARDENING: Should NOT contain internal ID and should mask full name
+        assertThat(dossier).doesNotContain("123")
+        assertThat(dossier).contains("J. DOE")
+        assertThat(dossier).doesNotContain("JOHN DOE")
         assertThat(dossier).contains("Status")
         assertThat(dossier).contains("Neural Metrics")
     }


### PR DESCRIPTION
### 🛡️ Shield: Privacy Hardening for Neural Dossiers

#### 🔓 The Vulnerability
The "Neural Dossier" feature in Ghost Lab was leaking Personally Identifiable Information (PII) and internal system state when shared:
1. **Full Name Exposure**: Student full names were included in the cleartext `Intent.EXTRA_SUBJECT` of the Android share sheet and in the header of the generated Markdown report.
2. **Internal ID Leakage**: The database `Long` ID was included in the report, providing no pedagogical value while exposing internal system architecture.

#### 🔐 The Fix
- **Name Masking**: Implemented a masking algorithm that reduces full names to an initial and last name (e.g., "John Doe" becomes "J. DOE"). This is applied to both the report header in `GhostLinkEngine.kt` and the share intent subject in `SeatingChartScreen.kt`.
- **ID Removal**: Explicitly removed the "Internal ID" field from the generated Markdown dossier content.
- **Test Alignment**: Updated `GhostLinkEngineTest.kt` to enforce these privacy standards via automated assertions.

#### 📜 Compliance
This hardening effort aligns with **OWASP Mobile Top 10 (M4: Insecure Data Storage / M5: Insecure Communication)** and Google Play's **Data Safety** requirements by minimizing the export of sensitive student data to system-level frameworks and external applications.

---
*PR created automatically by Jules for task [8814280812373238244](https://jules.google.com/task/8814280812373238244) started by @YMSeatt*