### PR TITLE
🛡️ Shield: Hardening GhostMementoStore with Encryption

### DIFF
--- a/app/src/main/java/com/example/myapplication/labs/ghost/memento/GhostMementoStore.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/memento/GhostMementoStore.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import com.example.myapplication.util.SecurityUtil
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
@@ -25,7 +26,8 @@ private val Context.mementoDataStore: DataStore<Preferences> by preferencesDataS
  */
 @Singleton
 class GhostMementoStore @Inject constructor(
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    private val securityUtil: SecurityUtil
 ) {
     private object Keys {
         val COMMAND_HISTORY = stringPreferencesKey("command_history")
@@ -33,12 +35,13 @@ class GhostMementoStore @Inject constructor(
 
     /**
      * Reactive stream of the persisted command history.
-     * Deserializes the JSON state into a [MementoHistory] object.
+     * Decrypts and deserializes the JSON state into a [MementoHistory] object.
      */
     val commandHistoryFlow: Flow<MementoHistory> = context.mementoDataStore.data.map { prefs ->
-        val json = prefs[Keys.COMMAND_HISTORY]
-        if (json != null) {
+        val encryptedJson = prefs[Keys.COMMAND_HISTORY]
+        if (encryptedJson != null) {
             try {
+                val json = securityUtil.decryptSafe(encryptedJson)
                 Json.decodeFromString<MementoHistory>(json)
             } catch (e: Exception) {
                 MementoHistory()
@@ -50,12 +53,13 @@ class GhostMementoStore @Inject constructor(
 
     /**
      * Atomically updates the persisted command history.
-     * Serializes the [MementoHistory] into JSON before storage.
+     * Serializes and encrypts the [MementoHistory] into JSON before storage.
      */
     suspend fun saveHistory(history: MementoHistory) {
         val json = Json.encodeToString(history)
+        val encryptedJson = securityUtil.encrypt(json)
         context.mementoDataStore.edit { prefs ->
-            prefs[Keys.COMMAND_HISTORY] = json
+            prefs[Keys.COMMAND_HISTORY] = encryptedJson
         }
     }
 

--- a/app/src/test/java/com/example/myapplication/labs/ghost/memento/GhostMementoStoreTest.kt
+++ b/app/src/test/java/com/example/myapplication/labs/ghost/memento/GhostMementoStoreTest.kt
@@ -1,0 +1,66 @@
+package com.example.myapplication.labs.ghost.memento
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.example.myapplication.util.SecurityUtil
+import io.mockk.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class GhostMementoStoreTest {
+
+    private lateinit var context: Context
+    private lateinit var securityUtil: SecurityUtil
+    private lateinit var store: GhostMementoStore
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        securityUtil = mockk()
+        store = GhostMementoStore(context, securityUtil)
+    }
+
+    @Test
+    fun `test saveHistory encrypts data`() = runTest {
+        val history = MementoHistory(undoStack = emptyList(), redoStack = emptyList())
+        val json = "{\"undoStack\":[],\"redoStack\":[]}"
+        val encryptedJson = "encrypted_json"
+
+        every { securityUtil.encrypt(any<String>()) } returns encryptedJson
+
+        store.saveHistory(history)
+
+        // Since we cannot easily inspect the internal DataStore,
+        // we verify that the encryption was called.
+        verify { securityUtil.encrypt(any<String>()) }
+    }
+
+    @Test
+    fun `test commandHistoryFlow decrypts data`() = runTest {
+        // This test is harder because it relies on DataStore's internal state.
+        // However, we can verify that when we call saveHistory, it uses encryption.
+        // And we can trust that commandHistoryFlow uses decryption as implemented.
+
+        val history = MementoHistory(undoStack = emptyList(), redoStack = emptyList())
+        val encryptedJson = "encrypted_json"
+        val decryptedJson = "{\"undoStack\":[],\"redoStack\":[]}"
+
+        every { securityUtil.encrypt(any<String>()) } returns encryptedJson
+        every { securityUtil.decryptSafe(encryptedJson) } returns decryptedJson
+
+        store.saveHistory(history)
+
+        val result = store.commandHistoryFlow.first()
+
+        verify { securityUtil.decryptSafe(encryptedJson) }
+        assertEquals(history, result)
+    }
+}


### PR DESCRIPTION
### 🛡️ Shield: [Security Hardening] in [Ghost Lab / Memento]
 
🔓 *The Vulnerability:* The `GhostMementoStore` was persisting the application's entire command history (undo/redo stacks) as plain-text JSON in a dedicated DataStore. This history included `Student` entities, `BehaviorEvent`s, and `QuizLog`s, exposing sensitive student PII (names, behavior notes) at rest.
 
🔐 *The Fix:* Hardened `GhostMementoStore` by integrating the project's standard `SecurityUtil`. All command history is now encrypted using AES-256 (Fernet) backed by the Android KeyStore before being written to disk. The retrieval flow uses `decryptSafe` to ensure that any existing unencrypted history is migrated without data loss.
 
📜 *Compliance:* This aligns with OWASP MASVS (Data Storage and Privacy) and Google Play Safety standards by ensuring PII is "Secure-at-Rest".

---
*PR created automatically by Jules for task [9073536854459355095](https://jules.google.com/task/9073536854459355095) started by @YMSeatt*