### PR TITLE
⚡ Bolt: Optimize GhostMagnetarLayer performance

### DIFF
--- a/app/src/main/java/com/example/myapplication/labs/ghost/magnetar/GhostMagnetarLayer.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/magnetar/GhostMagnetarLayer.kt
@@ -33,10 +33,6 @@ fun GhostMagnetarLayer(
     // and maintain 60fps fragment throughput.
     val studentsToDisplay = remember(students) { students.take(15) }
 
-    val dipoles = remember(studentsToDisplay) {
-        engine.calculateDipoles(studentsToDisplay)
-    }
-
     val infiniteTransition = rememberInfiniteTransition(label = "magnetarTime")
     val time by infiniteTransition.animateFloat(
         initialValue = 0f,
@@ -61,16 +57,18 @@ fun GhostMagnetarLayer(
         // Passes device orientation to the shader to skew the visual field lines
         shader.setFloatUniform("iHeading", heading)
 
-        val count = dipoles.size
+        val count = studentsToDisplay.size
         shader.setIntUniform("iDipoleCount", count)
 
-        // BOLT: Use manual index loop to eliminate iterator and 'take' allocations in the draw pass.
+        // BOLT: Read properties directly from StudentUiItem MutableState. This allows
+        // 60fps fluid tracking during student drag operations as field lines follow
+        // the icon without whole-layer recomposition or redundant object allocations.
         for (index in 0 until count) {
-            val dipole = dipoles[index]
+            val student = studentsToDisplay[index]
             // Map logical coordinates to screen space
-            posArray[index * 2] = dipole.x * canvasScale + canvasOffset.x
-            posArray[index * 2 + 1] = dipole.y * canvasScale + canvasOffset.y
-            strengthArray[index] = dipole.strength
+            posArray[index * 2] = student.xPosition.value * canvasScale + canvasOffset.x
+            posArray[index * 2 + 1] = student.yPosition.value * canvasScale + canvasOffset.y
+            strengthArray[index] = student.magneticStrength.value
         }
 
         shader.setFloatUniform("iDipolePos", posArray)


### PR DESCRIPTION
🐢 *The Bottleneck:* `GhostMagnetarLayer.kt` was using a `remember`ed list of `MagneticDipole` objects, which were calculated by a helper function. Because `SeatingChartViewModel` reuses `StudentUiItem` instances, updating properties like student position during a drag operation did not trigger a re-calculation of the dipoles, leading to laggy or non-existent visual feedback. Additionally, the `MagneticDipole` objects were redundant allocations in the high-frequency draw path.

🐇 *The Fix:* Refactored the layer to read student properties directly from their `MutableState` fields inside the `Canvas` draw pass. This bypasses the need for the intermediate list and allows Compose's draw phase to react to position changes without full recomposition.

📉 *The Impact:* 
- **Reduced Allocations:** Eliminated up to 15 `MagneticDipole` objects and one `List` allocation per update cycle.
- **Improved Smoothness:** Enabled 60fps real-time tracking of magnetic field lines during student drag-and-drop gestures.
- **Cleaner Logic:** Reduced dependency on the engine's legacy mapping function in the UI layer.

---
*PR created automatically by Jules for task [15209951272442809272](https://jules.google.com/task/15209951272442809272) started by @YMSeatt*