### PR TITLE
📜 Scribe: Documentation update for Assignment and Template subsystem

### DIFF
--- a/app/src/main/java/com/example/myapplication/data/HomeworkDao.kt
+++ b/app/src/main/java/com/example/myapplication/data/HomeworkDao.kt
@@ -3,31 +3,63 @@ package com.example.myapplication.data
 import androidx.room.*
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Data Access Object for the Normalized Homework subsystem.
+ *
+ * This DAO manages the creation of multi-step [HomeworkTemplate] blueprints
+ * and student-specific [Homework] completion records.
+ */
 @Dao
 interface HomeworkDao {
-    // HomeworkTemplate operations
+    // --- HomeworkTemplate operations ---
+
+    /**
+     * Persists a new multi-step homework blueprint.
+     */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertHomeworkTemplate(template: HomeworkTemplate)
 
+    /**
+     * Updates an existing homework blueprint.
+     */
     @Update
     suspend fun updateHomeworkTemplate(template: HomeworkTemplate)
 
+    /**
+     * Removes a homework blueprint from the database.
+     */
     @Delete
     suspend fun deleteHomeworkTemplate(template: HomeworkTemplate)
 
+    /**
+     * Returns a reactive stream of all available homework templates.
+     */
     @Query("SELECT * FROM homework_templates")
     fun getAllHomeworkTemplates(): Flow<List<HomeworkTemplate>>
 
-    // Homework operations
+    // --- Homework operations ---
+
+    /**
+     * Persists an individual student's homework completion record.
+     */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertHomework(homework: Homework)
 
+    /**
+     * Updates an existing homework completion record.
+     */
     @Update
     suspend fun updateHomework(homework: Homework)
 
+    /**
+     * Removes a homework record from history.
+     */
     @Delete
     suspend fun deleteHomework(homework: Homework)
 
+    /**
+     * Returns a reactive stream of all homework records for a specific student.
+     */
     @Query("SELECT * FROM homework WHERE student_id = :studentId")
     fun getHomeworkForStudent(studentId: Long): Flow<List<Homework>>
 }

--- a/app/src/main/java/com/example/myapplication/data/HomeworkTemplate.kt
+++ b/app/src/main/java/com/example/myapplication/data/HomeworkTemplate.kt
@@ -8,12 +8,29 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import java.util.UUID
 
+/**
+ * Defines the supported input types for a homework assignment step.
+ */
 enum class HomeworkMarkType {
+    /** A simple binary toggle (e.g., "Signed by Parent"). */
     CHECKBOX,
+    /** A numeric score or rating (e.g., "Effort: 4/5"). */
     SCORE,
+    /** A free-text observation or note. */
     COMMENT
 }
 
+/**
+ * Represents a single component or "step" of a homework assignment.
+ *
+ * A homework assignment can consist of multiple parts (e.g., "Math Exercises", "Parent Signature").
+ * Each step has a specific input type and optional maximum value.
+ *
+ * @property id Unique identifier for the step (UUID generated at creation).
+ * @property label The display name of the step (e.g., "Reading Log").
+ * @property type The input interaction style (Checkbox, Score, or Comment).
+ * @property maxValue The maximum allowed value for [HomeworkMarkType.SCORE] types.
+ */
 data class HomeworkMarkStep(
     val id: String = UUID.randomUUID().toString(),
     val label: String,
@@ -21,6 +38,17 @@ data class HomeworkMarkStep(
     val maxValue: Int = 1
 )
 
+/**
+ * Represents a reusable blueprint for a complex homework assignment or check-in.
+ *
+ * A template defines a sequence of [HomeworkMarkStep]s. This allows teachers to
+ * create standardized "Checking" routines that are reused across different sessions.
+ *
+ * @property id Unique identifier for the template.
+ * @property name The display name of the assignment template (e.g., "Weekly Math Pack").
+ * @property marksData A JSON-serialized list of [HomeworkMarkStep] objects. This structure
+ *           provides flexibility for ad-hoc assignment changes without schema migrations.
+ */
 @Entity(tableName = "homework_templates")
 data class HomeworkTemplate(
     @PrimaryKey(autoGenerate = true)
@@ -28,6 +56,9 @@ data class HomeworkTemplate(
     val name: String,
     val marksData: String // JSON string for List<HomeworkMarkStep>
 ) {
+    /**
+     * Deserializes the [marksData] into a list of [HomeworkMarkStep] objects.
+     */
     fun getSteps(): List<HomeworkMarkStep> {
         return try {
             val type = object : TypeToken<List<HomeworkMarkStep>>() {}.type
@@ -38,6 +69,9 @@ data class HomeworkTemplate(
     }
 
     companion object {
+        /**
+         * Helper to create a [HomeworkTemplate] from a list of steps.
+         */
         fun fromSteps(name: String, steps: List<HomeworkMarkStep>, id: Long = 0): HomeworkTemplate {
             return HomeworkTemplate(
                 id = id,
@@ -48,6 +82,18 @@ data class HomeworkTemplate(
     }
 }
 
+/**
+ * Represents an individual student's completion record for a [HomeworkTemplate].
+ *
+ * While legacy [HomeworkLog] entities are used for quick, unstructured notes,
+ * the [Homework] entity provides a relational link to standardized templates.
+ *
+ * @property id Unique identifier for this homework record.
+ * @property studentId Foreign key referencing the [Student].
+ * @property templateId Foreign key referencing the [HomeworkTemplate] blueprint.
+ * @property status A summary status of the assignment (e.g., "Incomplete", "Satisfactory").
+ * @property timestamp The time the homework status was recorded.
+ */
 @Entity(
     tableName = "homework",
     foreignKeys = [

--- a/app/src/main/java/com/example/myapplication/data/QuizDao.kt
+++ b/app/src/main/java/com/example/myapplication/data/QuizDao.kt
@@ -3,31 +3,63 @@ package com.example.myapplication.data
 import androidx.room.*
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Data Access Object for the Normalized Quiz subsystem.
+ *
+ * This DAO manages both the creation of reusable [QuizTemplate] blueprints
+ * and the recording of individual [Quiz] attempts by students.
+ */
 @Dao
 interface QuizDao {
-    // QuizTemplate operations
+    // --- QuizTemplate operations ---
+
+    /**
+     * Persists a new quiz blueprint.
+     */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertQuizTemplate(template: QuizTemplate)
 
+    /**
+     * Updates an existing quiz blueprint.
+     */
     @Update
     suspend fun updateQuizTemplate(template: QuizTemplate)
 
+    /**
+     * Removes a quiz blueprint from the database.
+     */
     @Delete
     suspend fun deleteQuizTemplate(template: QuizTemplate)
 
+    /**
+     * Returns a reactive stream of all available quiz templates.
+     */
     @Query("SELECT * FROM quiz_templates")
     fun getAllQuizTemplates(): Flow<List<QuizTemplate>>
 
-    // Quiz operations
+    // --- Quiz operations ---
+
+    /**
+     * Persists an individual student's quiz attempt.
+     */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertQuiz(quiz: Quiz)
 
+    /**
+     * Updates an existing student quiz record.
+     */
     @Update
     suspend fun updateQuiz(quiz: Quiz)
 
+    /**
+     * Removes a quiz attempt from history.
+     */
     @Delete
     suspend fun deleteQuiz(quiz: Quiz)
 
+    /**
+     * Returns a reactive stream of all quiz attempts for a specific student.
+     */
     @Query("SELECT * FROM quizzes WHERE student_id = :studentId")
     fun getQuizzesForStudent(studentId: Long): Flow<List<Quiz>>
 }

--- a/app/src/main/java/com/example/myapplication/data/QuizTemplate.kt
+++ b/app/src/main/java/com/example/myapplication/data/QuizTemplate.kt
@@ -6,6 +6,20 @@ import androidx.room.PrimaryKey
 import androidx.room.ColumnInfo
 import androidx.room.ForeignKey
 
+/**
+ * Represents a reusable blueprint for a classroom quiz or assessment.
+ *
+ * Unlike legacy [QuizLog] entities which use a hybrid JSON approach for all data,
+ * the [QuizTemplate] and [Quiz] model follows a normalized strategy. A template
+ * defines the "shape" of an assessment (name, question count, and default scoring),
+ * which can then be instantiated multiple times for different students.
+ *
+ * @property id Unique identifier for the template.
+ * @property name The display name of the quiz (e.g., "Unit 1 Vocabulary").
+ * @property numQuestions The total number of questions or items in this quiz.
+ * @property defaultMarks A mapping of mark type names (e.g., "Correct", "Half Credit")
+ *           to their default occurrences or weights. This allows for rapid session setup.
+ */
 @Entity(tableName = "quiz_templates")
 data class QuizTemplate(
     @PrimaryKey(autoGenerate = true)
@@ -15,6 +29,19 @@ data class QuizTemplate(
     val defaultMarks: Map<String, Int>
 )
 
+/**
+ * Represents an individual student's performance on a specific [QuizTemplate].
+ *
+ * This entity links a student's final score and attempt timestamp to a reusable template.
+ * It provides a more structured relational alternative to the legacy [QuizLog] for
+ * high-level academic tracking.
+ *
+ * @property id Unique identifier for this quiz attempt.
+ * @property studentId Foreign key referencing the [Student] who took the quiz.
+ * @property templateId Foreign key referencing the [QuizTemplate] blueprint used.
+ * @property score The final calculated score for the attempt.
+ * @property timestamp The time the assessment was completed.
+ */
 @Entity(
     tableName = "quizzes",
     foreignKeys = [

--- a/app/src/main/java/com/example/myapplication/data/README.md
+++ b/app/src/main/java/com/example/myapplication/data/README.md
@@ -21,11 +21,26 @@ The data model is organized into three primary clusters:
     *   **LayoutTemplate**: Snapshots of student/furniture arrangements.
     *   **QuizTemplate** / **HomeworkTemplate**: Reusable structures for common classroom assignments.
 
+## 🧪 Normalized Assignment Model (Modern) vs. Legacy Log Model
+
+The application is currently transitioning from a flat, log-based history to a normalized, template-based assignment system.
+
+### 1. Legacy Log Model (`QuizLog`, `HomeworkLog`, `BehaviorEvent`)
+*   **Architecture**: Optimized for rapid, unstructured data entry. Every log is self-contained.
+*   **Flexibility**: Uses **JSON-Backed Storage** (`marksData`) for granular scoring metrics. This prevents frequent schema migrations as UI reporting needs change.
+*   **Use Case**: Best for quick "one-off" notes or historical records where strict template adherence isn't required.
+
+### 2. Normalized Assignment Model (`Quiz`, `Homework`, `QuizTemplate`, `HomeworkTemplate`)
+*   **Architecture**: Highly structured and relational. Assignments are instantiated from reusable **Templates**.
+*   **Consistency**: Ensures that assessments (like a "Unit 1 Quiz") follow a consistent schema (number of questions, specific scoring steps) across all students.
+*   **Benefits**: Easier to perform longitudinal analysis on specific assessments and supports multi-step homework check-ins (Checkboxes, Scores, and Comments).
+*   **Use Case**: Preferred for standardized classroom assessments and structured checking routines.
+
 ## ⚡ JSON-Backed Flexibility (The "Future-Proofing" Strategy)
 
 To avoid frequent and disruptive schema migrations as the UI evolves, specific entities utilize a hybrid storage approach:
 
-*   **`QuizLog.marksData`** and **`HomeworkLog.marksData`**: Instead of adding a new column for every possible scoring metric (e.g., "Partial Credit", "Late Penalty", "Oral Fluency"), these entities store complex scoring maps as **JSON strings**.
+*   **`QuizLog.marksData`** and **`HomeworkTemplate.marksData`**: These store complex scoring maps or multi-step assignment structures as **JSON strings**.
 *   **Benefits**: This allows the application to support dynamic scoring types and experimental metrics without altering the underlying SQLite tables, ensuring better compatibility between different app versions.
 
 ## ⛓️ Referential Integrity & Cascading


### PR DESCRIPTION
🔦 *The Blind Spot:* The application is transitioning from a legacy "flat log" model to a modern "normalized assignment" model, but the new entities (`Quiz`, `Homework`, `QuizTemplate`, `HomeworkTemplate`) and their respective DAOs were completely undocumented, making it unclear how they differ from the legacy `QuizLog` and `HomeworkLog` structures.

💡 *The Insight:* I implemented comprehensive KDoc across the entire assignment subsystem. I clarified that `Templates` act as reusable blueprints (e.g., a specific "Unit 1 Quiz") while `Quiz`/`Homework` instances track individual student progress. I also updated the `data` package README to explicitly guide developers on when to use each model.

📖 *Preview:*
```kotlin
/**
 * Represents a reusable blueprint for a classroom quiz or assessment.
 * ...
 * @property defaultMarks A mapping of mark type names (e.g., "Correct")
 *           to their default occurrences or weights.
 */
@Entity(tableName = "quiz_templates")
data class QuizTemplate(...)
```

---
*PR created automatically by Jules for task [3743228175857802784](https://jules.google.com/task/3743228175857802784) started by @YMSeatt*