### PR TITLE
🛡️ Shield: [Security Hardening] in File Ingestion

### DIFF
--- a/app/src/main/java/com/example/myapplication/data/importer/Importer.kt
+++ b/app/src/main/java/com/example/myapplication/data/importer/Importer.kt
@@ -131,13 +131,25 @@ class Importer(
         withContext(Dispatchers.IO) {
             try {
                 val maxSizeBytes = 50 * 1024 * 1024L // 50MB limit
-                context.contentResolver.openAssetFileDescriptor(uri, "r")?.use { afd ->
-                    if (afd.length > maxSizeBytes) {
-                        throw SecurityException("Import failed: File exceeds 50MB limit.")
-                    }
-                }
 
-                val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                val inputStream = context.contentResolver.openInputStream(uri)
+                    ?: throw java.io.FileNotFoundException("Could not open input stream for $uri")
+
+                val bytes = inputStream.use { stream ->
+                    val bos = java.io.ByteArrayOutputStream()
+                    val buffer = ByteArray(8192)
+                    var bytesRead: Int
+                    var totalBytesRead = 0L
+
+                    while (stream.read(buffer).also { bytesRead = it } != -1) {
+                        totalBytesRead += bytesRead
+                        if (totalBytesRead > maxSizeBytes) {
+                            throw SecurityException("Import failed: File exceeds 50MB limit.")
+                        }
+                        bos.write(buffer, 0, bytesRead)
+                    }
+                    bos.toByteArray()
+                }
 
                 if (bytes != null) {
                     val jsonString = if (encryptDataFilesFlow.first()) {

--- a/app/src/main/java/com/example/myapplication/data/importer/JsonImporter.kt
+++ b/app/src/main/java/com/example/myapplication/data/importer/JsonImporter.kt
@@ -135,17 +135,24 @@ class JsonImporter @Inject constructor(
     private fun readFileContent(uri: Uri): String {
         val maxSizeBytes = 50 * 1024 * 1024L // 50MB limit
 
-        context.contentResolver.openAssetFileDescriptor(uri, "r")?.use { afd ->
-            if (afd.length > maxSizeBytes) {
-                throw SecurityException("Import failed: File exceeds 50MB limit.")
-            }
-        }
-
         val inputStream = context.contentResolver.openInputStream(uri)
             ?: throw java.io.FileNotFoundException("Could not open input stream for $uri")
 
-        val reader = BufferedReader(InputStreamReader(inputStream))
-        return reader.readText()
+        inputStream.use { stream ->
+            val bos = java.io.ByteArrayOutputStream()
+            val buffer = ByteArray(8192)
+            var bytesRead: Int
+            var totalBytesRead = 0L
+
+            while (stream.read(buffer).also { bytesRead = it } != -1) {
+                totalBytesRead += bytesRead
+                if (totalBytesRead > maxSizeBytes) {
+                    throw SecurityException("Import failed: File exceeds 50MB limit.")
+                }
+                bos.write(buffer, 0, bytesRead)
+            }
+            return bos.toString("UTF-8")
+        }
     }
 
     private suspend fun importClassroomData(uri: Uri) {

--- a/app/src/main/java/com/example/myapplication/util/ExcelImportUtil.kt
+++ b/app/src/main/java/com/example/myapplication/util/ExcelImportUtil.kt
@@ -92,15 +92,12 @@ object ExcelImportUtil {
     ): Result<Int> = withContext(Dispatchers.IO) {
         try {
             val maxSizeBytes = 50 * 1024 * 1024L // 50MB limit
-            context.contentResolver.openAssetFileDescriptor(uri, "r")?.use { afd ->
-                if (afd.length > maxSizeBytes) {
-                    throw SecurityException("Import failed: File exceeds 50MB limit.")
-                }
-            }
 
             val inputStream: InputStream? = context.contentResolver.openInputStream(uri)
             inputStream.use { stream ->
-                val workbook = WorkbookFactory.create(stream)
+                if (stream == null) return@withContext Result.success(0)
+                val limitedStream = LimitedInputStream(stream, maxSizeBytes)
+                val workbook = WorkbookFactory.create(limitedStream)
                 val sheet = workbook.getSheetAt(0)
                 val rows = sheet.iterator()
 
@@ -200,6 +197,42 @@ object ExcelImportUtil {
         } catch (e: Exception) {
             Log.e(TAG, "Failed to import from Excel", e)
             Result.failure(e)
+        }
+    }
+
+    /**
+     * A wrapper [InputStream] that enforces a maximum byte limit.
+     * Throws [SecurityException] if the limit is exceeded.
+     */
+    private class LimitedInputStream(private val inputStream: InputStream, private val maxSize: Long) : InputStream() {
+        private var bytesRead = 0L
+
+        override fun read(): Int {
+            val result = inputStream.read()
+            if (result != -1) {
+                bytesRead++
+                checkSize()
+            }
+            return result
+        }
+
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            val result = inputStream.read(b, off, len)
+            if (result != -1) {
+                bytesRead += result
+                checkSize()
+            }
+            return result
+        }
+
+        private fun checkSize() {
+            if (bytesRead > maxSize) {
+                throw SecurityException("Import failed: File exceeds 50MB limit.")
+            }
+        }
+
+        override fun close() {
+            inputStream.close()
         }
     }
 }


### PR DESCRIPTION
This patch hardens the application's file ingestion logic against resource exhaustion (DoS/OOM) attacks. Previously, the app relied on `AssetFileDescriptor.getLength()` to enforce a 50MB limit, which could be bypassed if the length was unknown. The new implementation uses a streaming approach that manually tracks bytes read across three critical import paths: generic JSON imports, fragmented JSON imports, and Excel student roster imports.

---
*PR created automatically by Jules for task [9629130596139611173](https://jules.google.com/task/9629130596139611173) started by @YMSeatt*