### PR TITLE
🌉 Bridge: Port Homework Initials Logic parity from Python

### DIFF
--- a/.jules/bridge.md
+++ b/.jules/bridge.md
@@ -37,3 +37,7 @@ LaunchedEffect(autoLockEnabled, autoLockTimeoutMinutes, unlocked, lastActivityTi
 ## 2026-03-05 - Ghost Architect Layout Analysis Port
 **Discrepancy:** The Python prototype uses `ghost_architect_analysis.py` to calculate 'Layout Synergy' and 'Strategic Alignment' scores based on Euclidean distance with 1000/1500 thresholds. The Android application had a basic layout proposer but lacked the scoring and reporting logic.
 **Adaptation:** Ported `calculateSynergy` and `generateReport` into `GhostArchitectEngine.kt`. Adjusted distance constants (1000 -> 2000, 1500 -> 3000) to account for the 2x scale difference in Android's 4000x4000 logical coordinate system. Used `Locale.US` for Markdown report formatting to maintain parity with Python's numeric string output.
+
+## 2028-05-15 - Homework Initials Logic Parity
+**Discrepancy:** The Python prototype maps homework initials based on the status string (e.g., "Done", "Late") rather than the assignment name. The Android application was incorrectly using the assignment name for initials mapping and displayed assignment types in the "Manage Initials" screen.
+**Adaptation:** Modified `SeatingChartViewModel.kt` to apply `homeworkInitialsMap` to the `log.status` field. Updated `ManageInitialsScreen.kt` to populate the "Homework" tab with `customHomeworkStatuses` to ensure the user can configure initials for the correct set of labels, matching Python's logical behavior.

--- a/app/src/main/java/com/example/myapplication/ui/settings/ManageInitialsScreen.kt
+++ b/app/src/main/java/com/example/myapplication/ui/settings/ManageInitialsScreen.kt
@@ -45,7 +45,7 @@ fun ManageInitialsScreen(
     val systemBehaviors by viewModel.allSystemBehaviors.observeAsState(initial = emptyList())
     val customBehaviors by viewModel.customBehaviors.observeAsState(initial = emptyList())
 
-    val homeworkTypes by viewModel.customHomeworkTypes.observeAsState(initial = emptyList())
+    val homeworkStatuses by viewModel.customHomeworkStatuses.observeAsState(initial = emptyList())
 
     val quizTemplates by viewModel.allQuizTemplates.observeAsState(initial = emptyList())
 
@@ -86,7 +86,7 @@ fun ManageInitialsScreen(
                     )
                 }
                 1 -> {
-                    val allHomework = homeworkTypes.map { it.name }.distinct()
+                    val allHomework = homeworkStatuses.map { it.name }.distinct()
                     InitialsList(
                         items = allHomework,
                         initialsMapStr = homeworkInitialsMapStr,

--- a/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
@@ -1316,13 +1316,13 @@ class SeatingChartViewModel @Inject constructor(
                                 if (log.loggedAt <= lastCleared) break
                                 if (homeworkDisplayTimeout > 0 && currentTime >= log.loggedAt + timeoutMs) break
 
-                                val status = if (log.isComplete) "Done" else "Not Done"
-                                val prefix = if (useInitialsForHomework) {
-                                    homeworkInitialsMap[log.assignmentName] ?: log.assignmentName.first().toString()
+                                val status = log.status
+                                val statusDescription = if (useInitialsForHomework) {
+                                    homeworkInitialsMap[status] ?: if (status.isNotEmpty()) status.first().toString() else "?"
                                 } else {
-                                    log.assignmentName
+                                    status
                                 }
-                                homeworkDescription.add("$prefix: $status")
+                                homeworkDescription.add("${log.assignmentName}: $statusDescription")
                             }
                         }
 
@@ -1357,7 +1357,14 @@ class SeatingChartViewModel @Inject constructor(
                             if (hLogsSess != null) {
                                 for (i in 0 until hLogsSess.size) {
                                     if (sLogs.size >= maxLogsToDisplay) break
-                                    sLogs.add("${hLogsSess[i].assignmentName}: ${hLogsSess[i].status}")
+                                    val log = hLogsSess[i]
+                                    val status = log.status
+                                    val statusDescription = if (useInitialsForHomework) {
+                                        homeworkInitialsMap[status] ?: if (status.isNotEmpty()) status.first().toString() else "?"
+                                    } else {
+                                        status
+                                    }
+                                    sLogs.add("${log.assignmentName}: $statusDescription")
                                 }
                             }
                             sLogs


### PR DESCRIPTION
This PR synchronizes the homework initials logic between the Android application and the Python prototype.

### Changes:
- **Logic Layer**: Updated `SeatingChartViewModel`'s `updateStudentsForDisplay` pipeline to apply `homeworkInitialsMap` to the homework `status` field rather than the assignment name. This ensures that labels like "Done" or "Late" can be properly abbreviated (e.g., "D", "L") on student icons.
- **UI Layer**: Modified `ManageInitialsScreen`'s "Homework" tab to populate from `customHomeworkStatuses` (labels like "Done", "Late") instead of `customHomeworkTypes` (labels like "Reading Assignment").
- **Documentation**: Added a journal entry to `.jules/bridge.md` documenting the discrepancy and adaptation for future interoperability efforts.

### Verification:
- Syntactic and logical inspection confirms parity with Python's `initial_overrides_key` selection in `seatingchartmain.py`.
- Verified that `HomeworkLog` contains the required `status` field.
- Verified that `SettingsViewModel` provides `customHomeworkStatuses`.

---
*PR created automatically by Jules for task [8124917424540648136](https://jules.google.com/task/8124917424540648136) started by @YMSeatt*