### PR TITLE
🛡️ Shield: ID-Only Protocol and Screen Protection in Ghost Morph

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -91,3 +91,11 @@
     - Implemented a mandatory 50MB size limit for **all** database operations (backup, share, restore) regardless of encryption status.
     - Hardened `shareDatabase` to use unique, timestamp-based filenames to prevent collisions in the shared cache.
 - **Location:** `app/src/main/java/com/example/myapplication/viewmodel/SettingsViewModel.kt`
+
+## 🛡️ Privacy Hardening: ID-Only Intent Protocol & Screen Protection
+- **Vulnerability:** Student PII (full name) was passed via Intent extras to `GhostMorphActivity`, potentially exposing it to system logs or malicious Intent interceptors. Additionally, the sensitive 'Neural Dossier' screen lacked protection against screenshots and screen recordings.
+- **Fix:**
+    - Transitioned to an **ID-Only Intent Protocol** for the Neural Morph transition.
+    - Updated `GhostMorphActivity` to fetch the student name directly from the secure local database using the provided ID.
+    - Enforced `WindowManager.LayoutParams.FLAG_SECURE` in `GhostMorphActivity` to prevent unauthorized data capture.
+- **Location:** `app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt`, `app/src/main/java/com/example/myapplication/labs/ghost/morph/GhostMorphActivity.kt`

--- a/app/src/main/java/com/example/myapplication/labs/ghost/morph/GhostMorphActivity.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/morph/GhostMorphActivity.kt
@@ -1,6 +1,7 @@
 package com.example.myapplication.labs.ghost.morph
 
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.animation.*
@@ -13,8 +14,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.example.myapplication.data.StudentDao
 import com.example.myapplication.ui.theme.MyApplicationTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.background
 
@@ -28,15 +31,24 @@ import androidx.compose.foundation.background
 @AndroidEntryPoint
 class GhostMorphActivity : ComponentActivity() {
 
+    @Inject
+    lateinit var studentDao: StudentDao
+
     @OptIn(ExperimentalSharedTransitionApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // HARDEN: Prevent screenshots and screen recordings of sensitive Neural Dossiers
+        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
 
         val studentId = intent.getLongExtra("STUDENT_ID", -1L)
-        val studentName = intent.getStringExtra("STUDENT_NAME") ?: "Unknown Student"
 
         setContent {
             MyApplicationTheme {
+                val studentName by produceState(initialValue = "Loading...") {
+                    val student = studentDao.getStudentByIdNonLiveData(studentId)
+                    value = student?.let { "${it.firstName} ${it.lastName}" } ?: "Unknown Student"
+                }
+
                 var isDossierVisible by remember { mutableStateOf(false) }
 
                 LaunchedEffect(Unit) {

--- a/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
+++ b/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
@@ -1788,7 +1788,6 @@ fun SeatingChartScreen(
                                     selectedStudentUiItemForAction?.let { student ->
                                         val intent = Intent(context, com.example.myapplication.labs.ghost.morph.GhostMorphActivity::class.java).apply {
                                             putExtra("STUDENT_ID", student.id.toLong())
-                                            putExtra("STUDENT_NAME", student.fullName.value)
                                             // Pass triggering position for potential transition refinement
                                             putExtra("TRIGGER_X", studentHubPosition.x)
                                             putExtra("TRIGGER_Y", studentHubPosition.y)


### PR DESCRIPTION
### 🛡️ Security & Privacy Hardening: Ghost Morph

This patch strengthens the privacy posture of the "Ghost Morph" experimental feature by reducing PII exposure during inter-process communication and protecting sensitive data from unauthorized capture.

#### 🔓 The Vulnerability
1. **PII Leakage in Intents**: The student's full name was being passed as a plaintext extra in the `Intent` used to launch `GhostMorphActivity`. Intents can be persisted by the system or potentially intercepted, leading to unnecessary exposure of student PII.
2. **Screen Capture Risk**: The "Neural Dossier" generated in `GhostMorphActivity` contains sensitive classroom analysis which was vulnerable to screenshots or screen recordings.

#### 🔐 The Fix
1. **ID-Only Intent Protocol**: Modified `SeatingChartScreen.kt` to only pass the student's internal ID. `GhostMorphActivity` now uses this ID to fetch the name directly from the app's secure local database.
2. **Asynchronous Data Retrieval**: Leveraged Jetpack Compose's `produceState` and Hilt-injected `StudentDao` to fetch student details asynchronously upon activity launch.
3. **Hardware-Level Screen Protection**: Enforced `FLAG_SECURE` on the `GhostMorphActivity` window. This instructs the Android system to prevent screenshots and treat the window's content as secure during screen recording or casting.

#### 📜 Compliance
- Aligns with **OWASP MASVS-STORAGE** (Privacy of sensitive data) and **MASVS-RESILIENCE** (Reverse Engineering and Injection defense).
- Follows Google Play's best practices for **Data Minimization** and **PII Protection**.

Verified syntactically via automated scripts and manual code review. full Gradle compilation was bypassed due to a known environmental Metadata version conflict.

---
*PR created automatically by Jules for task [9432255651760246353](https://jules.google.com/task/9432255651760246353) started by @YMSeatt*