### PR TITLE
📜 Scribe: Documentation update for Ghost Memento persistence

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -70,3 +70,9 @@
     - `FORCE_FRICTION (-100f)`: Repulsion is weighted 1.6x more heavily than `FORCE_COLLABORATION (60f)` to highlight disruptive social dynamics.
     - `FORCE_NEUTRAL (15f)`: Provides a baseline "social cohesion" pull even in the absence of explicit logs.
 - **Zero-Allocation Needle**: The `GhostVectorLayer` utilizes a pooled `RuntimeShader` approach to render hundreds of needles without triggering GC pauses, capturing uniforms just-in-time during the `Canvas` draw pass.
+
+### 15. Ghost Memento Architecture
+- **Metaphor**: A specialized "Long-Term Memory" engine for command history persistence.
+- **Persistence Strategy**: Uses a high-integrity mapping system (`GhostMementoMapper`) to transform complex production `Command` objects into pure-data `MementoCommand` DTOs.
+- **Encryption**: History is serialized to JSON and encrypted using `SecurityUtil` before storage in Jetpack DataStore, ensuring privacy for historical behavioral and academic records.
+- **Atomic Recovery**: The `SeatingChartViewModel` re-hydrates its undo/redo stacks from the store on launch, enabling a seamless "Resume Work" experience across app restarts.

--- a/app/src/main/java/com/example/myapplication/labs/ghost/memento/GhostMementoMapper.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/memento/GhostMementoMapper.kt
@@ -18,6 +18,9 @@ class GhostMementoMapper @Inject constructor() {
     /**
      * Maps a production [Command] to its serializable [MementoCommand] counterpart.
      * Uses exhaustive type checking to ensure all command types are handled.
+     *
+     * @param command The production command to decompose.
+     * @return A serializable DTO, or null if the command type is not supported for persistence.
      */
     fun toMemento(command: Command): MementoCommand? {
         return when (command) {
@@ -50,6 +53,10 @@ class GhostMementoMapper @Inject constructor() {
     /**
      * Reconstructs a production [Command] from a persisted [MementoCommand].
      * Requires a reference to the [SeatingChartViewModel] to wire up database dependencies.
+     *
+     * @param memento The serialized command DTO.
+     * @param viewModel The invoker and state manager for the seating chart.
+     * @return A live Command instance ready for execution or undo.
      */
     fun fromMemento(memento: MementoCommand, viewModel: SeatingChartViewModel): Command? {
         return when (memento) {

--- a/app/src/main/java/com/example/myapplication/labs/ghost/memento/MementoModels.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/memento/MementoModels.kt
@@ -138,6 +138,9 @@ sealed class MementoCommand {
         val commands: List<MementoCommand>
     ) : MementoCommand()
 
+    /**
+     * Bulk movement command for multiple students and/or furniture items.
+     */
     @Serializable
     data class MoveItems(
         override val description: String,
@@ -145,10 +148,27 @@ sealed class MementoCommand {
     ) : MementoCommand()
 }
 
+/**
+ * MementoItemMove: Captures the transformation of a single seating chart item.
+ *
+ * This DTO ensures that bulk move operations can be perfectly reconstructed.
+ * It stores full snapshots of the [student] or [furniture] entity to maintain
+ * referential integrity if the move is redone after the original item has
+ * been modified by other commands.
+ *
+ * @property id The database primary key of the item.
+ * @property itemType Discriminator string: "STUDENT" or "FURNITURE".
+ * @property oldX Original horizontal coordinate.
+ * @property oldY Original vertical coordinate.
+ * @property newX Target horizontal coordinate.
+ * @property newY Target vertical coordinate.
+ * @property student Complete snapshot of the student (null if itemType is "FURNITURE").
+ * @property furniture Complete snapshot of the furniture (null if itemType is "STUDENT").
+ */
 @Serializable
 data class MementoItemMove(
     val id: Long,
-    val itemType: String, // "STUDENT" or "FURNITURE"
+    val itemType: String,
     val oldX: Float,
     val oldY: Float,
     val newX: Float,

--- a/app/src/main/java/com/example/myapplication/labs/ghost/memento/README.md
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/memento/README.md
@@ -1,0 +1,37 @@
+# 💾 Ghost Memento: Persistent Command History
+
+## 🛰️ The Metaphor
+The **Ghost Memento** experiment takes its name from the classical "Memento" design pattern. Its role is to act as the classroom's "Long-Term Memory," capturing the application's internal state (specifically the Undo/Redo stacks) and externalizing it to persistent storage. This allows the application to "remember" its entire operational history even after a full system termination or device restart.
+
+## 🏛️ Architectural Components
+
+The Ghost Memento system is composed of three primary layers:
+
+### 1. The Models (`MementoModels.kt`)
+A collection of **Serializable Data Transfer Objects (DTOs)** that mirror the application's production `Command` hierarchy. These models are designed to be pure-data representations, stripped of any database or ViewModel dependencies, making them suitable for JSON serialization via `kotlinx.serialization`.
+- **`MementoHistory`**: The root container for the `undoStack` and `redoStack`.
+- **`MementoCommand`**: A sealed class hierarchy representing individual actions (e.g., `AddStudent`, `LogBehavior`, `MoveItems`).
+
+### 2. The Mapper (`GhostMementoMapper.kt`)
+The **Translation Bridge** between the live, operational `Command` objects and their serializable `MementoCommand` counterparts.
+- **`toMemento()`**: Decomposes a live command, extracting its minimal state (IDs, coordinates, log data) into a Memento.
+- **`fromMemento()`**: Reconstructs a fully functional command from a Memento, re-injecting the necessary `SeatingChartViewModel` or DAO dependencies required for execution.
+
+### 3. The Store (`GhostMementoStore.kt`)
+The **Persistence Engine** built on top of **Jetpack DataStore**.
+- **Encryption**: Leverages `SecurityUtil` to encrypt the serialized JSON history before it touches the disk, ensuring that historical data remains private and secure.
+- **Atomicity**: Utilizes DataStore's atomic update capabilities to ensure that the history stack never enters a corrupted state.
+- **Reactive Stream**: Provides a `Flow<MementoHistory>` that the `SeatingChartViewModel` observes to recover the history during application initialization.
+
+## 🔄 The Persistence Loop
+
+The Memento system operates in a continuous loop during the seating chart session:
+1. **Action**: A user performs an action (e.g., moves a student).
+2. **Execution**: A production `Command` is created and executed.
+3. **Capture**: The `SeatingChartViewModel` passes the updated undo stack to the `GhostMementoMapper`.
+4. **Serialization**: The Mapper converts the stack into a `MementoHistory` object.
+5. **Persistence**: The `GhostMementoStore` encrypts and saves the history to the DataStore.
+6. **Recovery**: On the next app launch, the ViewModel reads the history from the store and re-hydrates its undo/redo stacks, allowing the teacher to resume work seamlessly.
+
+---
+*Documentation love letter from Scribe 📜*


### PR DESCRIPTION
🔦 *The Blind Spot:* The `ghost/memento` package, which handles critical command history persistence and recovery, lacked architectural documentation and detailed KDocs for its mapping logic.
💡 *The Insight:* I implemented a comprehensive `README.md` explaining the "Long-Term Memory" metaphor, the three architectural layers (Models, Mapper, Store), and the continuous persistence loop. I also enhanced KDocs in `MementoModels.kt` and `GhostMementoMapper.kt` to clarify DTO roles and bi-directional mapping.
📖 *Preview:* The documentation now explicitly covers the encrypted Jetpack DataStore persistence and the atomic recovery of the Undo/Redo stacks.

---
*PR created automatically by Jules for task [12087896991691361560](https://jules.google.com/task/12087896991691361560) started by @YMSeatt*