### PR TITLE
🛡️ Shield: Privacy Hardening for Reminders Screen

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -99,3 +99,8 @@
     - Updated `GhostMorphActivity` to fetch the student name directly from the secure local database using the provided ID.
     - Enforced `WindowManager.LayoutParams.FLAG_SECURE` in `GhostMorphActivity` to prevent unauthorized data capture.
 - **Location:** `app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt`, `app/src/main/java/com/example/myapplication/labs/ghost/morph/GhostMorphActivity.kt`
+
+## 🛡️ Privacy Hardening: Screen Protection for Reminders
+- **Vulnerability:** The 'Reminders' screen, which often contains student PII and sensitive classroom tasks, lacked protection against screenshots and screen recordings.
+- **Fix:** Implemented a `DisposableEffect` in `RemindersScreen.kt` to proactively enforce `WindowManager.LayoutParams.FLAG_SECURE` whenever the screen is active.
+- **Location:** `app/src/main/java/com/example/myapplication/ui/screens/RemindersScreen.kt`

--- a/app/src/main/java/com/example/myapplication/ui/screens/RemindersScreen.kt
+++ b/app/src/main/java/com/example/myapplication/ui/screens/RemindersScreen.kt
@@ -50,7 +50,9 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
+import android.view.WindowManager
 import androidx.core.content.ContextCompat
+import com.example.myapplication.util.findActivity
 
 /**
  * RemindersScreen: The primary user interface for managing teacher reminders.
@@ -68,6 +70,15 @@ fun RemindersScreen(
     onDismiss: () -> Unit
 ) {
     val context = LocalContext.current
+
+    DisposableEffect(Unit) {
+        val activity = context.findActivity()
+        activity?.window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        onDispose {
+            activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+
     var showPermissionDialog by remember { mutableStateOf(false) }
 
     val requestPermissionLauncher = rememberLauncherForActivityResult(


### PR DESCRIPTION
### 🛡️ Shield: Privacy Hardening for Reminders System

#### 🔓 The Vulnerability
The **'Reminders'** screen displays teacher-created tasks and events which often contain sensitive **Personally Identifiable Information (PII)** such as student names and specific behavioral or academic notes. Previously, this screen lacked protection against unauthorized data capture via screenshots or screen recordings, creating a risk of PII leakage if a teacher's device was compromised or if recordings were shared unintentionally.

#### 🔐 The Fix
Implemented a proactive privacy shield in `RemindersScreen.kt` using Android's **`FLAG_SECURE`** window manager flag.
- **`DisposableEffect` Integration**: The flag is applied when the screen is composed and automatically cleared when the user navigates away, ensuring the security measure is scoped only to the sensitive content.
- **Robust Context Resolution**: Uses the project's `findActivity()` utility to correctly identify the host `Activity` even when the `Context` is wrapped (a common scenario in Hilt/Compose environments).
- **Journaling**: Documented the fix in `.jules/shield.md` to maintain the application's security history.

#### 📜 Compliance
This hardening aligns with **OWASP MASVS** (Mobile Application Security Verification Standard) guidelines regarding sensitive data exposure and **Google Play's Safety Section** requirements for protecting user-provided PII.

---
*Verified via syntactic inspection and manual logic verification against established patterns in `DataViewerScreen.kt` and `SettingsActivity.kt`.*

---
*PR created automatically by Jules for task [2908629962985707481](https://jules.google.com/task/2908629962985707481) started by @YMSeatt*