### PR TITLE
🛡️ Shield: [Security Hardening] in Ghost Lab Sandbox Activities

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -104,3 +104,8 @@
 - **Vulnerability:** The 'Reminders' screen, which often contains student PII and sensitive classroom tasks, lacked protection against screenshots and screen recordings.
 - **Fix:** Implemented a `DisposableEffect` in `RemindersScreen.kt` to proactively enforce `WindowManager.LayoutParams.FLAG_SECURE` whenever the screen is active.
 - **Location:** `app/src/main/java/com/example/myapplication/ui/screens/RemindersScreen.kt`
+
+## 🛡️ Privacy Hardening: Screen Protection for Ghost Lab Sandbox Activities
+- **Vulnerability:** Experimental sandbox activities (Cortex, Strategist, Vision, Ray, Filter, and Preferences) that process or display sensitive classroom data and student metrics lacked protection against screenshots and screen recordings.
+- **Fix:** Enforced `WindowManager.LayoutParams.FLAG_SECURE` in the `onCreate` method of all relevant sandbox activities.
+- **Location:** `app/src/main/java/com/example/myapplication/labs/ghost/` (Multiple Activities)

--- a/app/src/main/java/com/example/myapplication/labs/ghost/cortex/GhostCortexActivity.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/cortex/GhostCortexActivity.kt
@@ -1,6 +1,7 @@
 package com.example.myapplication.labs.ghost.cortex
 
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -35,6 +36,8 @@ class GhostCortexActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        // HARDEN: Prevent screenshots and screen recordings of sensitive neural history data
+        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         setContent {
             MyApplicationTheme {
                 GhostCortexScreen(onBack = { finish() })

--- a/app/src/main/java/com/example/myapplication/labs/ghost/filtering/GhostFilterActivity.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/filtering/GhostFilterActivity.kt
@@ -1,6 +1,7 @@
 package com.example.myapplication.labs.ghost.filtering
 
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -20,6 +21,8 @@ class GhostFilterActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // HARDEN: Prevent screenshots and screen recordings of sensitive filtered classroom data
+        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         setContent {
             MyApplicationTheme {
                 GhostFilterScreen(

--- a/app/src/main/java/com/example/myapplication/labs/ghost/preferences/GhostPreferencesActivity.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/preferences/GhostPreferencesActivity.kt
@@ -1,6 +1,7 @@
 package com.example.myapplication.labs.ghost.preferences
 
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -22,6 +23,8 @@ class GhostPreferencesActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // HARDEN: Prevent screenshots and screen recordings of sensitive experimental preferences
+        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         setContent {
             val themeMode by viewModel.themeMode.collectAsState()
             val dynamicColor by viewModel.dynamicColorEnabled.collectAsState()

--- a/app/src/main/java/com/example/myapplication/labs/ghost/ray/GhostRayActivity.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/ray/GhostRayActivity.kt
@@ -1,6 +1,7 @@
 package com.example.myapplication.labs.ghost.ray
 
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -28,6 +29,8 @@ class GhostRayActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        // HARDEN: Prevent screenshots and screen recordings of sensitive neural beam interactions
+        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         setContent {
             MyApplicationTheme {
                 GhostRayScreen(onBack = { finish() })

--- a/app/src/main/java/com/example/myapplication/labs/ghost/strategist/GhostStrategistActivity.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/strategist/GhostStrategistActivity.kt
@@ -1,6 +1,7 @@
 package com.example.myapplication.labs.ghost.strategist
 
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
@@ -34,6 +35,8 @@ class GhostStrategistActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        // HARDEN: Prevent screenshots and screen recordings of sensitive tactical data
+        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         setContent {
             MyApplicationTheme {
                 GhostStrategistScreen(onBack = { finish() })

--- a/app/src/main/java/com/example/myapplication/labs/ghost/vision/GhostVisionActivity.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/vision/GhostVisionActivity.kt
@@ -1,6 +1,7 @@
 package com.example.myapplication.labs.ghost.vision
 
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -31,6 +32,8 @@ class GhostVisionActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        // HARDEN: Prevent screenshots and screen recordings of sensitive AR-projected student data
+        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         setContent {
             MyApplicationTheme {
                 val viewModel: SeatingChartViewModel = viewModel()


### PR DESCRIPTION
Hardened multiple experimental activities in the Ghost Lab module by enforcing `FLAG_SECURE`. This prevents sensitive classroom data, AI-generated tactical interventions, and student metrics from being captured via screenshots or screen recordings. Activities updated: `GhostCortexActivity`, `GhostStrategistActivity`, `GhostVisionActivity`, `GhostRayActivity`, `GhostFilterActivity`, and `GhostPreferencesActivity`.

---
*PR created automatically by Jules for task [14194549487491546531](https://jules.google.com/task/14194549487491546531) started by @YMSeatt*