### PR TITLE
📜 Scribe: Documentation update for Normalized Assignment Model

### DIFF
--- a/app/src/main/java/com/example/myapplication/data/Homework.kt
+++ b/app/src/main/java/com/example/myapplication/data/Homework.kt
@@ -1,0 +1,55 @@
+package com.example.myapplication.data
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+
+/**
+ * Represents an individual student's completion record for a [HomeworkTemplate].
+ *
+ * ### Normalized Assignment Model
+ * This entity is part of the structured "Normalized Assignment Model." It provides a relational
+ * link between a student and a standardized [HomeworkTemplate].
+ *
+ * ### Architectural Contrast:
+ * - **Legacy Logs ([HomeworkLog])**: Best for rapid, unstructured, one-off notes or check-ins
+ *   where the criteria might vary significantly between students.
+ * - **Normalized Assignments ([Homework])**: Preferred for standardized classroom assessments
+ *   and structured routines. They ensure that all students are checked against the same
+ *   multi-step criteria defined in a [HomeworkTemplate].
+ *
+ * ### Usage:
+ * Once a [HomeworkTemplate] is created, a [Homework] record is generated for each student
+ * to track their progress and status relative to that specific blueprint.
+ *
+ * @property id Unique identifier for this homework record.
+ * @property studentId Foreign key referencing the [Student].
+ * @property templateId Foreign key referencing the [HomeworkTemplate] blueprint.
+ * @property status A summary status of the assignment (e.g., "Incomplete", "Satisfactory").
+ * @property timestamp The time the homework status was recorded.
+ */
+@Entity(
+    tableName = "homework",
+    foreignKeys = [
+        ForeignKey(
+            entity = Student::class,
+            parentColumns = ["id"],
+            childColumns = ["student_id"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = HomeworkTemplate::class,
+            parentColumns = ["id"],
+            childColumns = ["template_id"],
+            onDelete = ForeignKey.SET_NULL
+        )
+    ]
+)
+data class Homework(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @ColumnInfo(name = "student_id", index = true) val studentId: Long,
+    @ColumnInfo(name = "template_id", index = true) val templateId: Long?,
+    val status: String,
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/example/myapplication/data/HomeworkDao.kt
+++ b/app/src/main/java/com/example/myapplication/data/HomeworkDao.kt
@@ -6,8 +6,15 @@ import kotlinx.coroutines.flow.Flow
 /**
  * Data Access Object for the Normalized Homework subsystem.
  *
- * This DAO manages the creation of multi-step [HomeworkTemplate] blueprints
- * and student-specific [Homework] completion records.
+ * This DAO orchestrates the management of standardized homework assessments. It
+ * handles both the [HomeworkTemplate] blueprints (which define multi-step checking
+ * routines) and the student-specific [Homework] records.
+ *
+ * ### Comparison: HomeworkDao vs. HomeworkLogDao
+ * - **[HomeworkLogDao]**: Manages legacy, self-contained log entries. Ideal for quick,
+ *   unstructured feedback and notes.
+ * - **[HomeworkDao]**: Manages relational homework records. Required for tracking
+ *   student progress through complex, multi-component assignments defined by a template.
  */
 @Dao
 interface HomeworkDao {

--- a/app/src/main/java/com/example/myapplication/data/HomeworkTemplate.kt
+++ b/app/src/main/java/com/example/myapplication/data/HomeworkTemplate.kt
@@ -2,8 +2,6 @@ package com.example.myapplication.data
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import androidx.room.ColumnInfo
-import androidx.room.ForeignKey
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import java.util.UUID
@@ -41,8 +39,19 @@ data class HomeworkMarkStep(
 /**
  * Represents a reusable blueprint for a complex homework assignment or check-in.
  *
- * A template defines a sequence of [HomeworkMarkStep]s. This allows teachers to
- * create standardized "Checking" routines that are reused across different sessions.
+ * ### Architectural Intent:
+ * A [HomeworkTemplate] defines a sequence of [HomeworkMarkStep]s. This allows teachers to
+ * create standardized "Checking" routines (e.g., a "Weekly Review" consisting of a
+ * reading check, a parent signature, and an effort score) that are reused across
+ * different students and sessions.
+ *
+ * ### Why use Templates?
+ * 1. **Relational Consistency**: Replaces one-off "Logs" with structured records linked
+ *    to a specific assignment definition.
+ * 2. **Multi-Step Tracking**: Supports assignments with multiple distinct checking criteria
+ *    (Checkbox, Score, and Comment simultaneously).
+ * 3. **Pedagogical Alignment**: Facilitates longitudinal tracking of specific types of
+ *    assignments rather than just generic "Homework."
  *
  * @property id Unique identifier for the template.
  * @property name The display name of the assignment template (e.g., "Weekly Math Pack").
@@ -81,40 +90,3 @@ data class HomeworkTemplate(
         }
     }
 }
-
-/**
- * Represents an individual student's completion record for a [HomeworkTemplate].
- *
- * While legacy [HomeworkLog] entities are used for quick, unstructured notes,
- * the [Homework] entity provides a relational link to standardized templates.
- *
- * @property id Unique identifier for this homework record.
- * @property studentId Foreign key referencing the [Student].
- * @property templateId Foreign key referencing the [HomeworkTemplate] blueprint.
- * @property status A summary status of the assignment (e.g., "Incomplete", "Satisfactory").
- * @property timestamp The time the homework status was recorded.
- */
-@Entity(
-    tableName = "homework",
-    foreignKeys = [
-        ForeignKey(
-            entity = Student::class,
-            parentColumns = ["id"],
-            childColumns = ["student_id"],
-            onDelete = ForeignKey.CASCADE
-        ),
-        ForeignKey(
-            entity = HomeworkTemplate::class,
-            parentColumns = ["id"],
-            childColumns = ["template_id"],
-            onDelete = ForeignKey.SET_NULL
-        )
-    ]
-)
-data class Homework(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
-    @ColumnInfo(name = "student_id", index = true) val studentId: Long,
-    @ColumnInfo(name = "template_id", index = true) val templateId: Long?,
-    val status: String,
-    val timestamp: Long = System.currentTimeMillis()
-)

--- a/app/src/main/java/com/example/myapplication/data/Quiz.kt
+++ b/app/src/main/java/com/example/myapplication/data/Quiz.kt
@@ -1,0 +1,54 @@
+package com.example.myapplication.data
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+
+/**
+ * Represents an individual student's performance on a specific [QuizTemplate].
+ *
+ * ### Normalized Assignment Model
+ * This entity is part of the "Normalized Assignment Model," which provides a structured,
+ * relational alternative to the legacy [QuizLog]. While [QuizLog] uses a flexible JSON-backed
+ * approach for rapid, unstructured data entry, the [Quiz] entity links directly to a
+ * [QuizTemplate] blueprint.
+ *
+ * ### Key Benefits:
+ * 1. **Relational Integrity**: Maintains strict foreign key links to students and templates.
+ * 2. **Standardized Analysis**: Facilitates longitudinal analysis of specific assessments
+ *    (e.g., comparing "Unit 1 Quiz" results across multiple classes) because they share a
+ *    common template ID.
+ * 3. **Schema Stability**: Separates the assessment definition (Template) from the student's
+ *    performance (Quiz attempt).
+ *
+ * @property id Unique identifier for this quiz attempt.
+ * @property studentId Foreign key referencing the [Student] who took the quiz.
+ * @property templateId Foreign key referencing the [QuizTemplate] blueprint used.
+ * @property score The final calculated score for the attempt.
+ * @property timestamp The time the assessment was completed.
+ */
+@Entity(
+    tableName = "quizzes",
+    foreignKeys = [
+        ForeignKey(
+            entity = Student::class,
+            parentColumns = ["id"],
+            childColumns = ["student_id"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = QuizTemplate::class,
+            parentColumns = ["id"],
+            childColumns = ["template_id"],
+            onDelete = ForeignKey.SET_NULL
+        )
+    ]
+)
+data class Quiz(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @ColumnInfo(name = "student_id", index = true) val studentId: Long,
+    @ColumnInfo(name = "template_id", index = true) val templateId: Long?,
+    val score: Double,
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/example/myapplication/data/QuizDao.kt
+++ b/app/src/main/java/com/example/myapplication/data/QuizDao.kt
@@ -6,8 +6,15 @@ import kotlinx.coroutines.flow.Flow
 /**
  * Data Access Object for the Normalized Quiz subsystem.
  *
- * This DAO manages both the creation of reusable [QuizTemplate] blueprints
- * and the recording of individual [Quiz] attempts by students.
+ * This DAO manages the "Source of Truth" for standardized assessments. It maintains
+ * the lifecycle of both [QuizTemplate] blueprints and the individual student [Quiz]
+ * attempts.
+ *
+ * ### Comparison: QuizDao vs. QuizLogDao
+ * - **[QuizLogDao]**: Manages legacy, self-contained logs. Best for rapid entry and
+ *   maintaining compatibility with older data formats.
+ * - **[QuizDao]**: Manages relational assessment data. Preferred for generating
+ *   consistent longitudinal reports based on standardized templates.
  */
 @Dao
 interface QuizDao {

--- a/app/src/main/java/com/example/myapplication/data/QuizTemplate.kt
+++ b/app/src/main/java/com/example/myapplication/data/QuizTemplate.kt
@@ -3,16 +3,21 @@ package com.example.myapplication.data
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-import androidx.room.ColumnInfo
-import androidx.room.ForeignKey
-
 /**
  * Represents a reusable blueprint for a classroom quiz or assessment.
  *
- * Unlike legacy [QuizLog] entities which use a hybrid JSON approach for all data,
- * the [QuizTemplate] and [Quiz] model follows a normalized strategy. A template
- * defines the "shape" of an assessment (name, question count, and default scoring),
- * which can then be instantiated multiple times for different students.
+ * ### Architectural Intent:
+ * The [QuizTemplate] is the core of the "Normalized Assignment Model." It defines the
+ * "shape" of an assessment once, which can then be reused to create individual [Quiz]
+ * attempts for many students.
+ *
+ * ### Why use Templates?
+ * 1. **Consistency**: Ensures that a "Midterm Quiz" follows the same scoring rules for
+ *    everyone.
+ * 2. **Efficiency**: Allows teachers to define question counts and default mark distributions
+ *    (e.g., how many "Correct" marks are expected) once.
+ * 3. **Rich Analytics**: Enables the system to compare student performance across specific
+ *    standardized assessments.
  *
  * @property id Unique identifier for the template.
  * @property name The display name of the quiz (e.g., "Unit 1 Vocabulary").
@@ -27,42 +32,4 @@ data class QuizTemplate(
     val name: String,
     val numQuestions: Int,
     val defaultMarks: Map<String, Int>
-)
-
-/**
- * Represents an individual student's performance on a specific [QuizTemplate].
- *
- * This entity links a student's final score and attempt timestamp to a reusable template.
- * It provides a more structured relational alternative to the legacy [QuizLog] for
- * high-level academic tracking.
- *
- * @property id Unique identifier for this quiz attempt.
- * @property studentId Foreign key referencing the [Student] who took the quiz.
- * @property templateId Foreign key referencing the [QuizTemplate] blueprint used.
- * @property score The final calculated score for the attempt.
- * @property timestamp The time the assessment was completed.
- */
-@Entity(
-    tableName = "quizzes",
-    foreignKeys = [
-        ForeignKey(
-            entity = Student::class,
-            parentColumns = ["id"],
-            childColumns = ["student_id"],
-            onDelete = ForeignKey.CASCADE
-        ),
-        ForeignKey(
-            entity = QuizTemplate::class,
-            parentColumns = ["id"],
-            childColumns = ["template_id"],
-            onDelete = ForeignKey.SET_NULL
-        )
-    ]
-)
-data class Quiz(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
-    @ColumnInfo(name = "student_id", index = true) val studentId: Long,
-    @ColumnInfo(name = "template_id", index = true) val templateId: Long?,
-    val score: Double,
-    val timestamp: Long = System.currentTimeMillis()
 )

--- a/app/src/main/java/com/example/myapplication/data/README.md
+++ b/app/src/main/java/com/example/myapplication/data/README.md
@@ -36,6 +36,21 @@ The application is currently transitioning from a flat, log-based history to a n
 *   **Benefits**: Easier to perform longitudinal analysis on specific assessments and supports multi-step homework check-ins (Checkboxes, Scores, and Comments).
 *   **Use Case**: Preferred for standardized classroom assessments and structured checking routines.
 
+## 🔄 Comparison: Log Model vs. Normalized Model
+
+To assist with technical decision-making, the following table contrasts the two primary data strategies:
+
+| Feature | Legacy Log Model | Normalized Assignment Model |
+| :--- | :--- | :--- |
+| **Primary Entities** | `QuizLog`, `HomeworkLog` | `Quiz`, `Homework` |
+| **Blueprint** | None (Ad-hoc) | `QuizTemplate`, `HomeworkTemplate` |
+| **Flexibility** | High (Change schema per log) | Strict (Follows template) |
+| **Speed of Entry** | Fast (One-off) | Process-driven (Structured) |
+| **Analytics** | Individual / Time-based | Longitudinal / Comparative |
+| **Relational Depth**| Shallow | Deep (Linked to Templates) |
+
+**Recommendation**: Use the **Log Model** for rapid, eye-free logging during live instruction. Use the **Normalized Model** for planned assessments, weekly homework checks, and data-driven reporting cycles.
+
 ## ⚡ JSON-Backed Flexibility (The "Future-Proofing" Strategy)
 
 To avoid frequent and disruptive schema migrations as the UI evolves, specific entities utilize a hybrid storage approach:


### PR DESCRIPTION
This PR implements a comprehensive documentation overhaul for the application's assessment data models. It addresses a "blind spot" where the new Normalized Assignment Model was implicitly defined and poorly contrasted with the legacy Log Model.

### 🔦 The Blind Spot
The codebase contained two concurrent systems for tracking assessments (quizzes and homework), but the relationship and usage guidelines for each were undocumented. The newer `Quiz` and `Homework` entities were tucked away inside template files, making them hard to discover.

### 💡 The Insight
By promoting these entities to their own files and adding detailed KDocs, we ensure that future maintainers understand:
1. **Why** the transition to a normalized model was made (relational integrity, longitudinal analysis).
2. **When** to use each model (Logs for rapid instruction vs. Normalized for planned assessments).
3. **How** the DAOs differ in their architectural roles.

### 📖 Preview
The `data/README.md` now includes a decision-making table and recommendation guide to streamline technical choices during feature development.

---
*PR created automatically by Jules for task [7572926709538527636](https://jules.google.com/task/7572926709538527636) started by @YMSeatt*