### PR TITLE
Ghost Seeds: Native Android Shortcuts & Neural Deep-links

### DIFF
--- a/.jules/ghost_todo.md
+++ b/.jules/ghost_todo.md
@@ -1,8 +1,10 @@
 # 👻 Ghost Android Backlog
+- [ ] Idea: (e.g., "Add Dynamic Color/Material You toggle")
 
 ## 🚧 Active Construction
 
 ## ✅ Completed Enhancements
+- [DONE] 2028-06-18: Ghost Seeds - Native Home Screen Shortcuts & Neural Deep-links in `/labs/ghost/util/GhostSeedEngine.kt`
 - [DONE] 2028-06-15: Ghost Shell - Immersive Neural Dock in `/labs/ghost/shell`
 - [DONE] 2028-06-12: Ghost Neural Flux - Density-aware flow visualization in `/labs/ghost/`
 - [DONE] 2028-06-08: Ghost Neural PiP - Native Picture-in-Picture Climate Monitor in `/labs/ghost/pip/`

--- a/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -39,6 +39,8 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import com.example.myapplication.labs.ghost.util.GhostSeedEngine
+import com.example.myapplication.labs.ghost.morph.GhostDossierScreen
 import kotlinx.coroutines.delay
 
 /**
@@ -60,6 +62,13 @@ import kotlinx.coroutines.delay
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private var lastActivityTime by mutableStateOf(System.currentTimeMillis())
+    private var currentIntent by mutableStateOf<Intent?>(null)
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        currentIntent = intent
+    }
 
     override fun onUserInteraction() {
         super.onUserInteraction()
@@ -138,6 +147,8 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
+        currentIntent = intent
+
         // HARDEN: Cleanup temporary files on startup to protect privacy
         lifecycleScope.launch(Dispatchers.IO) {
             val cacheDir = applicationContext.cacheDir
@@ -182,6 +193,19 @@ class MainActivity : ComponentActivity() {
                 }
             }
 
+            var deepLinkStudentId by remember { mutableStateOf<Long?>(null) }
+            var deepLinkStudentName by remember { mutableStateOf<String?>(null) }
+
+            LaunchedEffect(currentIntent) {
+                currentIntent?.let { intent ->
+                    if (intent.action == GhostSeedEngine.ACTION_OPEN_DOSSIER) {
+                        deepLinkStudentId = intent.getLongExtra(GhostSeedEngine.EXTRA_STUDENT_ID, -1L)
+                        deepLinkStudentName = intent.getStringExtra(GhostSeedEngine.EXTRA_STUDENT_NAME)
+                        if (deepLinkStudentId == -1L) deepLinkStudentId = null
+                    }
+                }
+            }
+
             MyApplicationTheme(
                 darkTheme = when (currentAppThemeState) {
                     AppTheme.LIGHT -> false
@@ -194,7 +218,20 @@ class MainActivity : ComponentActivity() {
                 useBoldFont = useBoldFont
             ) {
                 if (unlocked) {
-                    if (showDataViewer) {
+                    if (deepLinkStudentId != null && deepLinkStudentName != null) {
+                        GhostDossierScreen(
+                            studentId = deepLinkStudentId!!,
+                            studentName = deepLinkStudentName!!,
+                            onDismiss = {
+                                deepLinkStudentId = null
+                                deepLinkStudentName = null
+                            }
+                        )
+                        BackHandler {
+                            deepLinkStudentId = null
+                            deepLinkStudentName = null
+                        }
+                    } else if (showDataViewer) {
                         DataViewerScreen(
                             seatingChartViewModel = seatingChartViewModel,
                             statsViewModel = statsViewModel,

--- a/app/src/main/java/com/example/myapplication/labs/ghost/GhostConfig.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/GhostConfig.kt
@@ -192,4 +192,7 @@ object GhostConfig {
 
     /** Enables "Ghost Shell" immersive neural dock. */
     const val SHELL_MODE_ENABLED = true
+
+    /** Enables "Ghost Seeds" native home screen shortcuts. */
+    const val SEED_MODE_ENABLED = true
 }

--- a/app/src/main/java/com/example/myapplication/labs/ghost/morph/GhostDossierScreen.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/morph/GhostDossierScreen.kt
@@ -20,8 +20,11 @@ import androidx.compose.ui.graphics.ShaderBrush
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.example.myapplication.labs.ghost.GhostConfig
 import com.example.myapplication.labs.ghost.GhostLinkEngine
+import com.example.myapplication.labs.ghost.util.GhostSeedEngine
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
 
 /**
  * GhostDossierScreen: A high-fidelity, full-screen student dossier.
@@ -159,14 +162,44 @@ fun GhostDossierScreen(
 
                 Spacer(modifier = Modifier.height(32.dp))
 
-                Button(
-                    onClick = onDismiss,
-                    modifier = Modifier.align(Alignment.CenterHorizontally),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = Color(0xFF6200EE)
-                    )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text("De-Phase Dossier")
+                    Button(
+                        onClick = onDismiss,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color(0xFF6200EE)
+                        )
+                    ) {
+                        Text("De-Phase")
+                    }
+
+                    if (GhostConfig.GHOST_MODE_ENABLED && GhostConfig.SEED_MODE_ENABLED) {
+                        val context = LocalContext.current
+                        Spacer(modifier = Modifier.width(16.dp))
+                        OutlinedButton(
+                            onClick = { GhostSeedEngine.pinStudentSeed(context, studentId, studentName) },
+                            colors = ButtonDefaults.outlinedButtonColors(contentColor = Color.Cyan),
+                            border = ButtonDefaults.outlinedButtonBorder.copy(
+                                brush = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                    ShaderBrush(remember {
+                                        RuntimeShader(GhostMorphShader.NEURAL_FLUID).apply {
+                                            setFloatUniform("iTime", time)
+                                            setFloatUniform("iResolution", 100f, 100f)
+                                            setColorUniform("iColor1", Color.Violet.toArgb())
+                                            setColorUniform("iColor2", Color.Cyan.toArgb())
+                                        }
+                                    })
+                                } else {
+                                    Brush.linearGradient(listOf(Color.Violet, Color.Cyan))
+                                }
+                            )
+                        ) {
+                            Text("Neural Seed")
+                        }
+                    }
                 }
 
                 Spacer(modifier = Modifier.height(64.dp))

--- a/app/src/main/java/com/example/myapplication/labs/ghost/util/GhostSeedEngine.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/util/GhostSeedEngine.kt
@@ -1,0 +1,81 @@
+package com.example.myapplication.labs.ghost.util
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ShortcutInfo
+import android.content.pm.ShortcutManager
+import android.graphics.drawable.Icon
+import android.os.Build
+import com.example.myapplication.MainActivity
+import com.example.myapplication.R
+
+/**
+ * GhostSeedEngine: Manages "Neural Seeds" (Native Android Shortcuts).
+ *
+ * This engine facilitates the creation of pinned and dynamic shortcuts on the Android
+ * home screen. It allows teachers to "seed" specific students to their home screen for
+ * instant access to their Neural Dossier.
+ */
+object GhostSeedEngine {
+
+    const val ACTION_OPEN_DOSSIER = "com.example.myapplication.labs.ghost.ACTION_OPEN_DOSSIER"
+    const val EXTRA_STUDENT_ID = "EXTRA_STUDENT_ID"
+    const val EXTRA_STUDENT_NAME = "EXTRA_STUDENT_NAME"
+
+    /**
+     * Requests the OS to pin a "Neural Seed" (shortcut) for a specific student.
+     * Only available on API 26+.
+     */
+    fun pinStudentSeed(context: Context, studentId: Long, studentName: String) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val shortcutManager = context.getSystemService(ShortcutManager::class.java) ?: return
+
+            if (shortcutManager.isRequestPinShortcutSupported) {
+                val intent = Intent(context, MainActivity::class.java).apply {
+                    action = ACTION_OPEN_DOSSIER
+                    putExtra(EXTRA_STUDENT_ID, studentId)
+                    putExtra(EXTRA_STUDENT_NAME, studentName)
+                    // Ensure the intent opens a fresh dossier context
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                }
+
+                val shortcut = ShortcutInfo.Builder(context, "student_$studentId")
+                    .setShortLabel(studentName.take(10))
+                    .setLongLabel("Neural Seed: $studentName")
+                    .setIcon(Icon.createWithResource(context, R.mipmap.ic_launcher))
+                    .setIntent(intent)
+                    .build()
+
+                shortcutManager.requestPinShortcut(shortcut, null)
+            }
+        }
+    }
+
+    /**
+     * Refreshes the "Recent Seeds" dynamic shortcuts based on recent activity.
+     */
+    fun refreshDynamicSeeds(context: Context, recentStudents: List<Pair<Long, String>>) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            val shortcutManager = context.getSystemService(ShortcutManager::class.java) ?: return
+
+            val dynamicShortcuts = recentStudents.take(4).map { (id, name) ->
+                val intent = Intent(context, MainActivity::class.java).apply {
+                    action = ACTION_OPEN_DOSSIER
+                    putExtra(EXTRA_STUDENT_ID, id)
+                    putExtra(EXTRA_STUDENT_NAME, name)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                }
+
+                ShortcutInfo.Builder(context, "dynamic_student_$id")
+                    .setShortLabel(name.take(10))
+                    .setLongLabel("Recent: $name")
+                    .setIcon(Icon.createWithResource(context, R.mipmap.ic_launcher))
+                    .setIntent(intent)
+                    .build()
+            }
+
+            shortcutManager.dynamicShortcuts = dynamicShortcuts
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
@@ -90,6 +90,7 @@ import com.example.myapplication.util.EmailWorker
 import com.example.myapplication.util.StringSimilarity
 import com.example.myapplication.labs.ghost.GhostCognitiveEngine
 import com.example.myapplication.labs.ghost.GhostOracle
+import com.example.myapplication.labs.ghost.util.GhostSeedEngine
 import com.example.myapplication.util.SecurityUtil
 import com.example.myapplication.labs.ghost.memento.GhostMementoStore
 import com.example.myapplication.labs.ghost.memento.GhostMementoMapper
@@ -1923,6 +1924,11 @@ class SeatingChartViewModel @Inject constructor(
             val commands = events.map { LogBehaviorCommand(this@SeatingChartViewModel, it) }
             val compositeCommand = CompositeCommand(commands, "Log ${events.size} behavior(s)")
             executeCommand(compositeCommand)
+
+            // GHOST: Refresh dynamic seeds with recently logged students
+            if (GhostConfig.GHOST_MODE_ENABLED && GhostConfig.SEED_MODE_ENABLED) {
+                refreshDynamicSeeds()
+            }
         }
     }
 
@@ -2620,6 +2626,26 @@ class SeatingChartViewModel @Inject constructor(
         viewModelScope.launch {
             val command = LogBehaviorCommand(this@SeatingChartViewModel, event)
             executeCommand(command)
+
+            // GHOST: Refresh dynamic seeds with recently logged students
+            if (GhostConfig.GHOST_MODE_ENABLED && GhostConfig.SEED_MODE_ENABLED) {
+                refreshDynamicSeeds()
+            }
+        }
+    }
+
+    private fun refreshDynamicSeeds() {
+        viewModelScope.launch {
+            val recentLogs = allBehaviorEvents.value ?: emptyList()
+            val recentStudents = recentLogs.take(10)
+                .mapNotNull { log ->
+                    val student = studentsForDisplay.value?.find { it.id.toLong() == log.studentId }
+                    if (student != null) student.id.toLong() to student.fullName.value else null
+                }
+                .distinctBy { it.first }
+                .take(4)
+
+            GhostSeedEngine.refreshDynamicSeeds(application, recentStudents)
         }
     }
 


### PR DESCRIPTION
This change implements the "Ghost Seeds" experiment, leveraging native Android `ShortcutManager` APIs to provide instant home-screen access to student Neural Dossiers.

Key features:
1. **Pinned Shortcuts**: Teachers can "seed" a student to their home screen directly from the Neural Dossier view.
2. **Dynamic Shortcuts**: The app automatically updates its dynamic shortcut list (accessible via long-press on the app icon) to show the 4 most recently interacted students.
3. **Neural Deep-linking**: Integrated a robust intent handling system in `MainActivity` that navigates directly to the student's dossier, supporting both cold starts and warm starts via `onNewIntent`.
4. **Safety & Performance**: All `RuntimeShader` usage is guarded by SDK version checks with functional fallbacks for older devices. Logic was verified via simulation to ensure BOLT performance standards.

The feature is controlled via `SEED_MODE_ENABLED` in `GhostConfig.kt`.

---
*PR created automatically by Jules for task [5867816768261820782](https://jules.google.com/task/5867816768261820782) started by @YMSeatt*