### PR TITLE
📜 Scribe: Documentation update for Quiz Scoring System

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -102,5 +102,10 @@
 - **Haptic Synchronization**: The `GhostPhasingEngine` triggers specific haptic markers at the 10% and 90% phase thresholds. This provides a tactile "pop" when the transition starts and when the physical UI is nearly extinguished.
 - **RenderEffect Pipeline**: Unlike standard overlays, Phasing uses `RenderEffect.createRuntimeShaderEffect` on the `graphicsLayer`. This allows the shader to sample the *entire* rendered content of the child Composable, enabling global effects like chromatic aberration and jitter that wouldn't be possible with simple brushes.
 
+### 20. Quiz Scoring & Mark Type Heuristics
+- **The "Correct" Dependency**: The `QuizScoreEngine` and `ConditionalFormattingEngine` rely on a specific naming convention to calculate percentages. The engine scans the `QuizMarkType` list for an entry named **"Correct"** (case-insensitive) to establish the base point value for the quiz denominator (`numQuestions * defaultPoints`).
+- **BOLT Scoring Context**: To maintain 60fps during bulk updates (where every student icon might trigger a score calculation), the engine utilizes a `QuizScoringContext`. This object pre-calculates mark type HashMaps once and is shared across all students in a single update pass using identity-based memoization (`===`).
+- **Legacy Fallback**: If a quiz has 0 questions or no granular mark data, the engine automatically falls back to the legacy `markValue / maxMarkValue` calculation to ensure historical data remains visible.
+
 ---
 *Documentation love letter from Scribe 📜*

--- a/app/src/main/java/com/example/myapplication/data/QuizMarkType.kt
+++ b/app/src/main/java/com/example/myapplication/data/QuizMarkType.kt
@@ -3,12 +3,37 @@ package com.example.myapplication.data
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
+/**
+ * Defines a category of mark that can be applied to a quiz question.
+ *
+ * This entity serves as the metadata definition for the granular marks stored in the
+ * `marksData` JSON field of [QuizLog]. It determines how individual marks (e.g., "Half Credit",
+ * "Correct") translate into numeric points during score calculation.
+ *
+ * ### Scoring Heuristics:
+ * - **Denominator Selection**: The engine (see [com.example.myapplication.util.QuizScoreEngine])
+ *   looks for a mark type named **"Correct"** that has [contributesToTotal] set to `true`.
+ *   The [defaultPoints] of this mark type is multiplied by `QuizLog.numQuestions` to
+ *   establish the maximum possible points (the denominator).
+ * - **Point Contribution**: Only mark types where [contributesToTotal] is `true` are summed
+ *   into the earned points (the numerator) by default.
+ * - **Extra Credit**: Marks flagged with [isExtraCredit] contribute to the earned points
+ *   but are generally excluded from the denominator calculation.
+ */
 @Entity(tableName = "quiz_mark_types")
 data class QuizMarkType(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,
+    /**
+     * The human-readable label for the mark (e.g., "Correct", "Participation").
+     * **Warning**: The scoring engine relies on the name "Correct" (case-insensitive)
+     * as a heuristic for the standard "full credit" mark.
+     */
     val name: String,
+    /** The number of points awarded for a single occurrence of this mark. */
     val defaultPoints: Double,
+    /** Whether occurrences of this mark should be summed toward the total quiz score. */
     val contributesToTotal: Boolean,
+    /** Whether this mark represents bonus points above the standard quiz total. */
     val isExtraCredit: Boolean
 )

--- a/app/src/main/java/com/example/myapplication/util/QuizScoreEngine.kt
+++ b/app/src/main/java/com/example/myapplication/util/QuizScoreEngine.kt
@@ -7,29 +7,60 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 /**
- * QuizScoreEngine: Centralized logic for calculating quiz percentages.
- * Ported from the Python blueprint for strict logical parity.
+ * Centralized engine for calculating quiz percentages from granular mark data.
  *
- * BOLT: Optimized with LruCache and identity-based memoization to avoid redundant
- * JSON parsing and O(N) list operations.
+ * This engine implements the core scoring algorithm ported from the Python reference
+ * implementation (`_calculate_quiz_score_percentage`). It transforms JSON-based mark counts
+ * into numeric percentages by applying point values defined in [QuizMarkType].
+ *
+ * ### BOLT (Performance-Obsessed) Architecture:
+ * - **LruCache**: Utilizes [decodedMarksCache] to avoid redundant JSON deserialization of
+ *   `marksData` strings across multiple rule evaluations.
+ * - **Identity-Based Memoization**: Uses [getScoringContext] to cache and reuse pre-calculated
+ *   lookups ([QuizScoringContext]) when the input list of [QuizMarkType] remains unchanged.
+ * - **Complexity**: Achieves $O(M + N)$ complexity (where M is marks in a log, N is total mark types)
+ *   by using HashMaps for mark type lookups instead of repeated list searches.
  */
 object QuizScoreEngine {
 
+    /** Shared JSON configuration for decoding mark data. */
     val json = Json { ignoreUnknownKeys = true }
+
+    /**
+     * Cache for decoded mark JSON strings. Keyed by the raw JSON string from `QuizLog.marksData`.
+     */
     private val decodedMarksCache = LruCache<String, Map<String, Int>>(1000)
 
     /**
-     * BOLT: Holds pre-calculated mappings and configurations for a specific set of quiz mark types.
-     * This avoids redundant O(N) searches and HashMap allocations during bulk calculations.
+     * A performance-optimized snapshot of mark type metadata.
+     *
+     * This internal class pre-calculates the necessary mappings and heuristics required
+     * for bulk scoring operations. By resolving these values once per UI update cycle,
+     * the engine eliminates redundant $O(N)$ searches and allocations inside the per-student loop.
+     *
+     * @property markTypesRef The source list of mark types used to build this context.
      */
     internal class QuizScoringContext(val markTypesRef: List<QuizMarkType>) {
+        /**
+         * The heuristic used to find the "standard" mark type for the denominator.
+         * Priority:
+         * 1. First mark type named "Correct" that contributes to the total.
+         * 2. First mark type found that contributes to the total.
+         */
         val correctMarkType = markTypesRef.find {
             it.name.equals("Correct", ignoreCase = true) && it.contributesToTotal
         } ?: markTypesRef.find { it.contributesToTotal }
 
+        /** The base point value assigned to a single question. Defaults to 1.0. */
         val defaultPointsPerMainQuestion = correctMarkType?.defaultPoints ?: 1.0
+
+        /** Fast lookup by Database ID (as String). */
         val markTypeMapById = markTypesRef.associateBy { it.id.toString() }
+
+        /** Fast lookup by Name. */
         val markTypeMapByName = markTypesRef.associateBy { it.name }
+
+        /** Pre-calculated sum of all contributing point values (unused in current denominator logic). */
         val sumDefaultPointsContributing = markTypesRef.filter { it.contributesToTotal }.sumOf { it.defaultPoints }
     }
 
@@ -37,8 +68,15 @@ object QuizScoreEngine {
     private var lastScoringContext: QuizScoringContext? = null
 
     /**
-     * Internal helper to retrieve or create a scoring context for the given mark types.
-     * Uses identity-based memoization for high-performance reuse.
+     * Resolves a [QuizScoringContext] for the given list of mark types.
+     *
+     * This method utilizes identity-based memoization (`===`). If the [quizMarkTypes] list
+     * is the same object instance as the last call, the cached context is returned immediately.
+     * This is critical for maintaining 60fps during seating chart updates where this
+     * method is called for every student icon.
+     *
+     * @param quizMarkTypes The list of mark types to analyze.
+     * @return An optimized context for scoring lookups.
      */
     internal fun getScoringContext(quizMarkTypes: List<QuizMarkType>): QuizScoringContext {
         val cached = lastScoringContext
@@ -51,8 +89,14 @@ object QuizScoreEngine {
     }
 
     /**
-     * Decodes the marksData JSON from a QuizLog into a Map of mark type IDs/Names to counts.
-     * BOLT: Uses LruCache to avoid redundant parsing.
+     * Decodes the granular marks from a [QuizLog] into a usable Map.
+     *
+     * To maximize performance, this method uses [decodedMarksCache] to store the results
+     * of expensive JSON deserialization. Subsequent calls with the same [QuizLog.marksData]
+     * string will return the cached Map in $O(1)$ time.
+     *
+     * @param log The quiz log containing the JSON marks string.
+     * @return A map of mark type IDs or names to their respective counts.
      */
     fun getMarksData(log: QuizLog): Map<String, Int> {
         if (log.marksData.isBlank() || log.marksData == "{}") return emptyMap()
@@ -66,19 +110,34 @@ object QuizScoreEngine {
     }
 
     /**
-     * Calculates the score percentage for a given quiz log entry.
-     * Logic matches Python's _calculate_quiz_score_percentage exactly.
+     * Calculates the score percentage for a quiz entry.
+     *
+     * This is a convenience overload that resolves a [QuizScoringContext] internally.
+     * For high-frequency callers (e.g., inside loops), use the [QuizScoringContext] overload instead.
      *
      * @param log The quiz log entry to evaluate.
-     * @param quizMarkTypes The list of available mark types to determine point values.
-     * @return The calculated percentage (0-100+) or null if calculation is not possible.
+     * @param quizMarkTypes The list of available mark types.
+     * @return The calculated percentage (0.0 to 100.0+), or null if the log lacks sufficient data.
      */
     fun calculatePercentage(log: QuizLog, quizMarkTypes: List<QuizMarkType>): Double? {
         return calculatePercentage(log, getScoringContext(quizMarkTypes))
     }
 
     /**
-     * Optimized overload that accepts a pre-calculated [QuizScoringContext].
+     * Calculates the score percentage for a quiz entry using a pre-resolved context.
+     *
+     * ### Algorithm Logic (Parity with Python):
+     * 1. **Zero-Question Check**: If `numQuestions <= 0`, it attempts a legacy fallback
+     *    using `markValue / maxMarkValue`.
+     * 2. **Denominator Calculation**: The max possible points is `numQuestions * defaultPointsPerMainQuestion`.
+     * 3. **Empty Data Check**: If `marksData` is empty but `markValue` exists, it uses the legacy value.
+     * 4. **Numerator Calculation**: Sums `count * defaultPoints` for every mark found in
+     *    `marksData` that has a corresponding [QuizMarkType] definition.
+     * 5. **Final Percentage**: `(Earned Points / Possible Points) * 100`.
+     *
+     * @param log The quiz log entry to evaluate.
+     * @param context The pre-calculated scoring metadata.
+     * @return The calculated percentage (0.0 to 100.0+), or null if the log lacks sufficient data.
      */
     internal fun calculatePercentage(log: QuizLog, context: QuizScoringContext): Double? {
         val marksDataMap = getMarksData(log)


### PR DESCRIPTION
🔦 *The Blind Spot:* The granular quiz scoring system and its associated metadata entity (`QuizMarkType`) were undocumented, obscuring the "BOLT" performance optimizations and a critical naming dependency ("Correct" mark heuristic).

💡 *The Insight:* I implemented detailed KDocs explaining the role of `QuizMarkType` as metadata for `QuizLog.marksData`, and documented the `QuizScoreEngine` scoring algorithm and its identity-based memoization strategy. I also added Entry 20 to Scribe's Journal to ensure this tribal knowledge is transparent for future maintainers.

---
*PR created automatically by Jules for task [4770811861107666667](https://jules.google.com/task/4770811861107666667) started by @YMSeatt*