### PR TITLE
🛡️ Shield: Harden Ghost Snapshots with PII Masking and Secure Storage

### DIFF
--- a/app/src/main/java/com/example/myapplication/labs/ghost/snapshot/GhostSnapshotEngine.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/snapshot/GhostSnapshotEngine.kt
@@ -1,18 +1,17 @@
 package com.example.myapplication.labs.ghost.snapshot
 
-import android.content.ContentValues
 import android.content.Context
 import android.graphics.*
 import android.net.Uri
-import android.os.Build
-import android.os.Environment
-import android.provider.MediaStore
 import android.util.Log
+import androidx.core.content.FileProvider
 import com.example.myapplication.ui.model.StudentUiItem
 import com.example.myapplication.ui.model.FurnitureUiItem
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.OutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.util.Locale
 
 /**
  * GhostSnapshotEngine: A high-fidelity spatial archival engine.
@@ -29,19 +28,28 @@ import java.io.OutputStream
  * - Uses [Dispatchers.IO] for heavy Bitmap rendering and disk I/O.
  * - Implements manual rendering using [android.graphics.Canvas] to bypass
  *   the overhead of the Compose UI tree for a 16-megapixel image.
+ *
+ * ### Shield (Security Hardening):
+ * 1. **PII Masking**: Student names are automatically masked (e.g., "J. DOE") during
+ *    the rendering process to prevent data leakage in shared images.
+ * 2. **Secure Storage**: Snapshots are stored in the app's internal shared cache
+ *    directory instead of the public Gallery.
+ * 3. **Controlled Access**: Uses [FileProvider] to grant temporary access to the
+ *    snapshot URI for sharing, ensuring no other apps can access the PII without
+ *    explicit user intent.
  */
 object GhostSnapshotEngine {
     private const val TAG = "GhostSnapshotEngine"
     private const val CANVAS_SIZE = 4000f
 
     /**
-     * Renders the seating chart and saves it to the device's gallery.
+     * Renders the seating chart and saves it to the app's internal secure cache.
      *
-     * @param context Android context for MediaStore access.
+     * @param context Android context for file operations and FileProvider access.
      * @param students List of students to render.
      * @param furniture List of furniture to render.
      * @param backgroundColor Background color of the canvas.
-     * @return The Uri of the saved image, or null if failed.
+     * @return The secure content Uri of the saved image, or null if failed.
      */
     suspend fun captureFullCanvas(
         context: Context,
@@ -121,17 +129,17 @@ object GhostSnapshotEngine {
                 }
                 canvas.drawText(student.initials.value, x + w / 2, y + h / 2 + (initialsPaint.textSize / 3), initialsPaint)
 
-                // Full Name
+                // Full Name (HARDEN: Masked PII)
                 val namePaint = Paint().apply {
                     color = Color.WHITE
                     textSize = 24f
                     textAlign = Paint.Align.CENTER
                 }
-                canvas.drawText(student.fullName.value, x + w / 2, y + h + 30, namePaint)
+                canvas.drawText(maskName(student.fullName.value), x + w / 2, y + h + 30, namePaint)
             }
 
-            // 5. Save to MediaStore
-            val savedUri = saveBitmapToGallery(context, bitmap)
+            // 5. Save to Internal Cache
+            val savedUri = saveBitmapToCache(context, bitmap)
             bitmap.recycle()
             savedUri
         } catch (e: Exception) {
@@ -140,37 +148,38 @@ object GhostSnapshotEngine {
         }
     }
 
-    private fun saveBitmapToGallery(context: Context, bitmap: Bitmap): Uri? {
+    /**
+     * Masks a student's name to prevent PII leakage in shared snapshots.
+     * Example: "John Doe" -> "J. DOE"
+     */
+    private fun maskName(name: String): String {
+        val parts = name.trim().split(Regex("\\s+"))
+        return if (parts.size >= 2) {
+            "${parts.first().take(1).uppercase(Locale.US)}. ${parts.last().uppercase(Locale.US)}"
+        } else {
+            name.uppercase(Locale.US)
+        }
+    }
+
+    private fun saveBitmapToCache(context: Context, bitmap: Bitmap): Uri? {
         val filename = "GhostSnapshot_${System.currentTimeMillis()}.png"
-        val contentValues = ContentValues().apply {
-            put(MediaStore.MediaColumns.DISPLAY_NAME, filename)
-            put(MediaStore.MediaColumns.MIME_TYPE, "image/png")
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_PICTURES + "/GhostSnapshots")
-                put(MediaStore.MediaColumns.IS_PENDING, 1)
+        val sharedDir = File(context.cacheDir, "shared")
+        if (!sharedDir.exists()) sharedDir.mkdirs()
+
+        val file = File(sharedDir, filename)
+
+        try {
+            FileOutputStream(file).use { outputStream ->
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
             }
+            return FileProvider.getUriForFile(
+                context,
+                "com.example.myapplication.fileprovider",
+                file
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to save snapshot to cache", e)
+            return null
         }
-
-        val resolver = context.contentResolver
-        val uri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
-
-        uri?.let {
-            var outputStream: OutputStream? = null
-            try {
-                outputStream = resolver.openOutputStream(it)
-                if (outputStream != null) {
-                    bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
-                }
-            } finally {
-                outputStream?.close()
-            }
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                contentValues.clear()
-                contentValues.put(MediaStore.MediaColumns.IS_PENDING, 0)
-                resolver.update(it, contentValues, null, null)
-            }
-        }
-        return uri
     }
 }

--- a/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
+++ b/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
@@ -2015,10 +2015,21 @@ fun SeatingChartScreen(
                                 if (GhostConfig.GHOST_MODE_ENABLED && GhostConfig.SNAPSHOT_MODE_ENABLED) {
                                     isSnapshotTriggered = true
                                     coroutineScope.launch {
+                                        // SHIELD: Clean up previous artifact before creating a new one
+                                        lastSharedArtifactUri?.let { oldUri ->
+                                            try { context.contentResolver.delete(oldUri, null, null) } catch (e: Exception) { /* Ignore */ }
+                                        }
+
                                         val bgColor = try { android.graphics.Color.parseColor(canvasBackgroundColor) } catch (e: Exception) { android.graphics.Color.BLACK }
                                         val uri = GhostSnapshotEngine.captureFullCanvas(context, students, furniture, bgColor)
                                         if (uri != null) {
-                                            Toast.makeText(context, "Ghost Snapshot Saved to Gallery! 👻", Toast.LENGTH_SHORT).show()
+                                            lastSharedArtifactUri = uri
+                                            val intent = Intent(Intent.ACTION_SEND).apply {
+                                                type = "image/png"
+                                                putExtra(Intent.EXTRA_STREAM, uri)
+                                                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                            }
+                                            context.startActivity(Intent.createChooser(intent, "Share Ghost Snapshot"))
                                         } else {
                                             Toast.makeText(context, "Snapshot Failed", Toast.LENGTH_SHORT).show()
                                         }


### PR DESCRIPTION
### 🛡️ Shield: Security Hardening in Ghost Snapshots

#### 🔓 The Vulnerability
The experimental "Ghost Snapshot" feature previously rendered the full 4000x4000 logical canvas with student full names and saved the resulting high-resolution image directly to the public Gallery (`DIRECTORY_PICTURES`). This made sensitive student PII and classroom layouts accessible to any application with media permissions and created a persistent privacy risk as files were not automatically purged.

#### 🔐 The Fix
1.  **PII Masking**: Implemented a `maskName` utility in `GhostSnapshotEngine.kt` that automatically formats student names (e.g., "John Doe" -> "J. DOE") during the rendering process, ensuring shared snapshots do not leak full names.
2.  **Secure Internal Storage**: Replaced `MediaStore` usage with the app's internal `cache/shared/` directory. Snapshots are now stored in a private area inaccessible to other apps.
3.  **Secure Sharing Protocol**: Integrated `FileProvider` to generate secure content URIs. The snapshot flow in `SeatingChartScreen.kt` now utilizes `Intent.ACTION_SEND`, granting temporary, explicit access to the chosen target app only.
4.  **Lifecycle Management & Cleanup**: Integrated the Ghost Snapshot URI into the existing `lastSharedArtifactUri` state. The app now proactively deletes the previous temporary file before creating a new one and performs a final cleanup when the screen is disposed, preventing storage leaks.

#### 📜 Compliance
This hardening aligns with **Google Play Safety standards** regarding PII protection and follows **OWASP MASVS** (Mobile Application Security Verification Standard) guidelines for data storage and IPC security by utilizing private storage and the `FileProvider` pattern.

---
*PR created automatically by Jules for task [12349381473212826610](https://jules.google.com/task/12349381473212826610) started by @YMSeatt*