### PR TITLE
🌉 Bridge: Port Homework Mark Types Management from Python

### DIFF
--- a/app/src/main/java/com/example/myapplication/data/HomeworkMarkMetadataDao.kt
+++ b/app/src/main/java/com/example/myapplication/data/HomeworkMarkMetadataDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
 
@@ -27,4 +28,13 @@ interface HomeworkMarkMetadataDao {
 
     @Query("DELETE FROM homework_mark_metadata")
     suspend fun deleteAll()
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(metadataList: List<HomeworkMarkMetadata>)
+
+    @Transaction
+    suspend fun replaceAll(metadataList: List<HomeworkMarkMetadata>) {
+        deleteAll()
+        insertAll(metadataList)
+    }
 }

--- a/app/src/main/java/com/example/myapplication/data/HomeworkMarkMetadataRepository.kt
+++ b/app/src/main/java/com/example/myapplication/data/HomeworkMarkMetadataRepository.kt
@@ -27,4 +27,12 @@ class HomeworkMarkMetadataRepository @Inject constructor(
     suspend fun deleteAll() {
         homeworkMarkMetadataDao.deleteAll()
     }
+
+    suspend fun insertAll(metadataList: List<HomeworkMarkMetadata>) {
+        homeworkMarkMetadataDao.insertAll(metadataList)
+    }
+
+    suspend fun replaceAll(metadataList: List<HomeworkMarkMetadata>) {
+        homeworkMarkMetadataDao.replaceAll(metadataList)
+    }
 }

--- a/app/src/main/java/com/example/myapplication/ui/dialogs/HomeworkMarkMetadataEditDialog.kt
+++ b/app/src/main/java/com/example/myapplication/ui/dialogs/HomeworkMarkMetadataEditDialog.kt
@@ -1,0 +1,75 @@
+package com.example.myapplication.ui.dialogs
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.example.myapplication.data.HomeworkMarkMetadata
+
+@Composable
+fun HomeworkMarkMetadataEditDialog(
+    onDismiss: () -> Unit,
+    onSave: (HomeworkMarkMetadata) -> Unit,
+    metadata: HomeworkMarkMetadata? = null
+) {
+    var name by remember { mutableStateOf(metadata?.name ?: "") }
+    var defaultPoints by remember { mutableStateOf(metadata?.defaultPoints?.toString() ?: "0.0") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(if (metadata == null) "Add Homework Mark Type" else "Edit Homework Mark Type") },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Name") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = defaultPoints,
+                    onValueChange = { defaultPoints = it },
+                    label = { Text("Default Points") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    val points = defaultPoints.toDoubleOrNull() ?: 0.0
+                    val newMetadata = HomeworkMarkMetadata(
+                        id = metadata?.id ?: 0,
+                        name = name,
+                        defaultPoints = points
+                    )
+                    onSave(newMetadata)
+                },
+                enabled = name.isNotBlank()
+            ) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/example/myapplication/ui/settings/AdvancedSettingsTab.kt
+++ b/app/src/main/java/com/example/myapplication/ui/settings/AdvancedSettingsTab.kt
@@ -21,6 +21,7 @@ fun AdvancedSettingsTab(
     onNavigateToReminders: () -> Unit,
     onNavigateToQuizTemplates: () -> Unit,
     onNavigateToQuizMarkTypes: () -> Unit,
+    onNavigateToHomeworkMarkTypes: () -> Unit,
     onNavigateToManageInitials: () -> Unit
 ) {
     LazyColumn(
@@ -81,6 +82,14 @@ fun AdvancedSettingsTab(
         item {
             Button(onClick = onNavigateToQuizMarkTypes, modifier = Modifier.fillMaxWidth()) {
                 Text("Manage Quiz Mark Types")
+            }
+        }
+        item {
+            Spacer(Modifier.height(8.dp))
+        }
+        item {
+            Button(onClick = onNavigateToHomeworkMarkTypes, modifier = Modifier.fillMaxWidth()) {
+                Text("Manage Homework Mark Types")
             }
         }
         item {

--- a/app/src/main/java/com/example/myapplication/ui/settings/HomeworkMarkMetadataScreen.kt
+++ b/app/src/main/java/com/example/myapplication/ui/settings/HomeworkMarkMetadataScreen.kt
@@ -1,0 +1,137 @@
+package com.example.myapplication.ui.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.myapplication.data.HomeworkMarkMetadata
+import com.example.myapplication.ui.dialogs.HomeworkMarkMetadataEditDialog
+import com.example.myapplication.viewmodel.HomeworkMarkMetadataViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeworkMarkMetadataScreen(
+    onDismiss: () -> Unit,
+    viewModel: HomeworkMarkMetadataViewModel = hiltViewModel()
+) {
+    val metadataList by viewModel.homeworkMarkMetadata.collectAsState()
+    var showEditDialog by remember { mutableStateOf(false) }
+    var selectedMetadata by remember { mutableStateOf<HomeworkMarkMetadata?>(null) }
+    var showResetConfirm by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Homework Mark Types") },
+                navigationIcon = {
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { showResetConfirm = true }) {
+                        Icon(Icons.Default.Refresh, contentDescription = "Reset to Defaults")
+                    }
+                }
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = {
+                selectedMetadata = null
+                showEditDialog = true
+            }) {
+                Icon(Icons.Default.Add, contentDescription = "Add Mark Type")
+            }
+        }
+    ) { paddingValues ->
+        Box(modifier = Modifier.padding(paddingValues).fillMaxSize()) {
+            if (metadataList.isEmpty()) {
+                Text("No homework mark types defined.", modifier = Modifier.align(Alignment.Center))
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(metadataList) { metadata ->
+                        ListItem(
+                            headlineContent = { Text(metadata.name) },
+                            supportingContent = {
+                                Text("Points: ${metadata.defaultPoints}")
+                            },
+                            trailingContent = {
+                                IconButton(onClick = { viewModel.delete(metadata) }) {
+                                    Icon(Icons.Default.Delete, contentDescription = "Delete")
+                                }
+                            },
+                            modifier = Modifier.clickable {
+                                selectedMetadata = metadata
+                                showEditDialog = true
+                            }
+                        )
+                        HorizontalDivider()
+                    }
+                }
+            }
+        }
+
+        if (showEditDialog) {
+            HomeworkMarkMetadataEditDialog(
+                onDismiss = { showEditDialog = false },
+                onSave = { metadata ->
+                    if (metadata.id == 0L) {
+                        viewModel.insert(metadata)
+                    } else {
+                        viewModel.update(metadata)
+                    }
+                    showEditDialog = false
+                },
+                metadata = selectedMetadata
+            )
+        }
+
+        if (showResetConfirm) {
+            AlertDialog(
+                onDismissRequest = { showResetConfirm = false },
+                title = { Text("Reset to Defaults") },
+                text = { Text("Are you sure you want to add the default homework mark types?") },
+                confirmButton = {
+                    TextButton(onClick = {
+                        viewModel.resetToDefaults()
+                        showResetConfirm = false
+                    }) {
+                        Text("Reset")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showResetConfirm = false }) {
+                        Text("Cancel")
+                    }
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapplication/ui/settings/SettingsNavHost.kt
+++ b/app/src/main/java/com/example/myapplication/ui/settings/SettingsNavHost.kt
@@ -44,6 +44,7 @@ fun SettingsNavHost(
                 onNavigateToQuizTemplates = { navController.navigate("quiz_templates") },
                 onNavigateToQuizMarkTypes = { navController.navigate("quiz_mark_types") },
                 onNavigateToHomeworkTemplates = { navController.navigate("homework_templates") },
+                onNavigateToHomeworkMarkTypes = { navController.navigate("homework_mark_types") },
                 onNavigateToManageInitials = { navController.navigate("manage_initials") },
                 onDismiss = onDismiss
             )
@@ -51,6 +52,11 @@ fun SettingsNavHost(
         composable("student_groups") {
             StudentGroupsScreen(
                 viewModel = studentGroupsViewModel,
+                onDismiss = { navController.popBackStack() }
+            )
+        }
+        composable("homework_mark_types") {
+            HomeworkMarkMetadataScreen(
                 onDismiss = { navController.popBackStack() }
             )
         }

--- a/app/src/main/java/com/example/myapplication/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/myapplication/ui/settings/SettingsScreen.kt
@@ -47,6 +47,7 @@ fun SettingsScreen(
     onNavigateToQuizTemplates: () -> Unit,
     onNavigateToQuizMarkTypes: () -> Unit,
     onNavigateToHomeworkTemplates: () -> Unit,
+    onNavigateToHomeworkMarkTypes: () -> Unit,
     onNavigateToManageInitials: () -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -166,6 +167,7 @@ fun SettingsScreen(
                         onNavigateToReminders = onNavigateToReminders,
                         onNavigateToQuizTemplates = onNavigateToQuizTemplates,
                         onNavigateToQuizMarkTypes = onNavigateToQuizMarkTypes,
+                        onNavigateToHomeworkMarkTypes = onNavigateToHomeworkMarkTypes,
                         onNavigateToManageInitials = onNavigateToManageInitials
                     )
                     4 -> SmtpSettingsTab(viewModel = settingsViewModel)

--- a/app/src/main/java/com/example/myapplication/viewmodel/HomeworkMarkMetadataViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/HomeworkMarkMetadataViewModel.kt
@@ -1,0 +1,59 @@
+package com.example.myapplication.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.myapplication.data.HomeworkMarkMetadata
+import com.example.myapplication.data.HomeworkMarkMetadataRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * HomeworkMarkMetadataViewModel: Manages the custom scoring categories for homework.
+ *
+ * This ViewModel provides the logic for adding, editing, deleting, and resetting
+ * homework mark metadata (e.g., "Complete" = 10 pts).
+ *
+ * ### Logic Parity
+ * Resets to defaults based on the Python blueprint:
+ * - Complete: 10.0
+ * - Incomplete: 5.0
+ * - Not Done: 0.0
+ * - Effort Score (1-5): 3.0
+ */
+@HiltViewModel
+class HomeworkMarkMetadataViewModel @Inject constructor(
+    private val repository: HomeworkMarkMetadataRepository
+) : ViewModel() {
+
+    val homeworkMarkMetadata = repository.getAll()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyList()
+        )
+
+    fun insert(metadata: HomeworkMarkMetadata) = viewModelScope.launch {
+        repository.insert(metadata)
+    }
+
+    fun update(metadata: HomeworkMarkMetadata) = viewModelScope.launch {
+        repository.update(metadata)
+    }
+
+    fun delete(metadata: HomeworkMarkMetadata) = viewModelScope.launch {
+        repository.delete(metadata)
+    }
+
+    fun resetToDefaults() = viewModelScope.launch {
+        val defaults = listOf(
+            HomeworkMarkMetadata(name = "Complete", defaultPoints = 10.0),
+            HomeworkMarkMetadata(name = "Incomplete", defaultPoints = 5.0),
+            HomeworkMarkMetadata(name = "Not Done", defaultPoints = 0.0),
+            HomeworkMarkMetadata(name = "Effort Score (1-5)", defaultPoints = 3.0)
+        )
+        repository.replaceAll(defaults)
+    }
+}


### PR DESCRIPTION
This change ports the Homework Mark Types Management feature from the Python desktop application to the Android application.

### 🐍 Source
Logic identified in `Python/quizhomework.py`, specifically the `ManageMarkTypesDialog` and `DEFAULT_HOMEWORK_MARK_TYPES` constants.

### 🤖 Implementation
- **Data Layer**: Enhanced `HomeworkMarkMetadataDao.kt` and `HomeworkMarkMetadataRepository.kt` with bulk operations.
- **Logic Layer**: Created `HomeworkMarkMetadataViewModel.kt` to manage scoring categories and reset to Python defaults.
- **UI Layer**: Implemented `HomeworkMarkMetadataScreen.kt` and `HomeworkMarkMetadataEditDialog.kt` using Jetpack Compose.
- **Navigation**: Integrated the new screen into `SettingsNavHost.kt` and `AdvancedSettingsTab.kt`.

### 🔄 Mapping Strategy
Translated Python's dictionary-based mark types into a Room-backed metadata system. Maintained logical parity for default values:
- Complete: 10.0
- Incomplete: 5.0
- Not Done: 0.0
- Effort Score: 3.0

### 🧪 Verification
Verified logical parity via syntactic inspection and manual verification of the implementation stack. Confirmed navigation wiring and Hilt-compatible architecture.

---
*PR created automatically by Jules for task [4541105561276347139](https://jules.google.com/task/4541105561276347139) started by @YMSeatt*