### PR TITLE
bridge/quiz-mark-initials

### DIFF
--- a/.jules/bridge.md
+++ b/.jules/bridge.md
@@ -41,3 +41,7 @@ LaunchedEffect(autoLockEnabled, autoLockTimeoutMinutes, unlocked, lastActivityTi
 ## 2028-05-15 - Homework Initials Logic Parity
 **Discrepancy:** The Python prototype maps homework initials based on the status string (e.g., "Done", "Late") rather than the assignment name. The Android application was incorrectly using the assignment name for initials mapping and displayed assignment types in the "Manage Initials" screen.
 **Adaptation:** Modified `SeatingChartViewModel.kt` to apply `homeworkInitialsMap` to the `log.status` field. Updated `ManageInitialsScreen.kt` to populate the "Homework" tab with `customHomeworkStatuses` to ensure the user can configure initials for the correct set of labels, matching Python's logical behavior.
+
+## 2024-05-20 - Quiz Mark Initials Discrepancy
+**Discrepancy:** Python combines Behaviors and Quiz Mark Types in a single initials map (`behavior_initial_overrides`). Android split them into tabs but omitted Quiz Mark Types from the customization UI entirely.
+**Adaptation:** Unified Quiz Mark Types into the "Behaviors" tab of `ManageInitialsScreen.kt` while maintaining the separate "Quizzes" tab for Template-specific initials to provide superior organization while keeping functional parity.

--- a/app/src/main/java/com/example/myapplication/ui/settings/ManageInitialsScreen.kt
+++ b/app/src/main/java/com/example/myapplication/ui/settings/ManageInitialsScreen.kt
@@ -44,6 +44,7 @@ fun ManageInitialsScreen(
 
     val systemBehaviors by viewModel.allSystemBehaviors.observeAsState(initial = emptyList())
     val customBehaviors by viewModel.customBehaviors.observeAsState(initial = emptyList())
+    val quizMarkTypes by viewModel.quizMarkTypes.observeAsState(initial = emptyList())
 
     val homeworkStatuses by viewModel.customHomeworkStatuses.observeAsState(initial = emptyList())
 
@@ -78,7 +79,9 @@ fun ManageInitialsScreen(
 
             when (selectedTabIndex) {
                 0 -> {
-                    val allBehaviors = (systemBehaviors.map { it.name } + customBehaviors.map { it.name }).distinct()
+                    val allBehaviors = (systemBehaviors.map { it.name } +
+                            customBehaviors.map { it.name } +
+                            quizMarkTypes.map { it.name }).distinct()
                     InitialsList(
                         items = allBehaviors,
                         initialsMapStr = behaviorInitialsMapStr,


### PR DESCRIPTION
Snake 🐍 Source: Reference to Python's behavior_initial_overrides usage for both behaviors and quiz mark types in update_all_behaviors (seatingchartmain.py).
Robot 🤖 Implementation: Modified ManageInitialsScreen.kt to observe quizMarkTypes and merge them into the 'Behaviors' tab initials list.
🔄 Mapping Strategy: Unified persistence by storing mark-type initials in the BEHAVIOR_INITIALS_MAP preference, while maintaining Android's distinct 'Quizzes' tab for template-specific initials.
🧪 Verification: Syntactic inspection and logical parity verification performed (noting the Hilt/Kapt build constraint in the sandbox).

---
*PR created automatically by Jules for task [11487422740258549619](https://jules.google.com/task/11487422740258549619) started by @YMSeatt*