### PR TITLE
📜 Scribe: Documentation update for Assessment Metadata cluster

### DIFF
--- a/app/src/main/java/com/example/myapplication/data/HomeworkMarkMetadataDao.kt
+++ b/app/src/main/java/com/example/myapplication/data/HomeworkMarkMetadataDao.kt
@@ -9,29 +9,60 @@ import androidx.room.Transaction
 import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Data Access Object for [HomeworkMarkMetadata] entities.
+ *
+ * This DAO manages the persistence of metadata used to map homework status labels
+ * (e.g., "Complete", "Submitted Late") to numeric point values.
+ */
 @Dao
 interface HomeworkMarkMetadataDao {
+    /**
+     * Observes all homework mark metadata, sorted alphabetically.
+     */
     @Query("SELECT * FROM homework_mark_metadata ORDER BY name ASC")
     fun getAllHomeworkMarkMetadata(): Flow<List<HomeworkMarkMetadata>>
 
+    /**
+     * Retrieves a one-shot list of all homework mark metadata.
+     */
     @Query("SELECT * FROM homework_mark_metadata ORDER BY name ASC")
     suspend fun getAllHomeworkMarkMetadataList(): List<HomeworkMarkMetadata>
 
+    /**
+     * Inserts a single metadata entry. Replaces on conflict.
+     */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(metadata: HomeworkMarkMetadata)
 
+    /**
+     * Updates an existing metadata entry's name or point value.
+     */
     @Update
     suspend fun update(metadata: HomeworkMarkMetadata)
 
+    /**
+     * Deletes a metadata entry.
+     */
     @Delete
     suspend fun delete(metadata: HomeworkMarkMetadata)
 
+    /**
+     * Clears all homework scoring metadata.
+     */
     @Query("DELETE FROM homework_mark_metadata")
     suspend fun deleteAll()
 
+    /**
+     * Inserts multiple metadata entries in a single operation.
+     */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(metadataList: List<HomeworkMarkMetadata>)
 
+    /**
+     * Atomically replaces the entire homework scoring metadata library.
+     * Often used during data sync or when restoring default scoring rules.
+     */
     @Transaction
     suspend fun replaceAll(metadataList: List<HomeworkMarkMetadata>) {
         deleteAll()

--- a/app/src/main/java/com/example/myapplication/data/HomeworkMarkMetadataRepository.kt
+++ b/app/src/main/java/com/example/myapplication/data/HomeworkMarkMetadataRepository.kt
@@ -4,34 +4,66 @@ import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Repository that coordinates access to [HomeworkMarkMetadata].
+ *
+ * This repository provides the business logic for managing the mapping of homework
+ * status labels to numeric point values. It is utilized by ViewModels to manage
+ * configurations and by the `HomeworkScoreEngine` to calculate longitudinal scores.
+ */
 @Singleton
 class HomeworkMarkMetadataRepository @Inject constructor(
     private val homeworkMarkMetadataDao: HomeworkMarkMetadataDao
 ) {
+    /**
+     * Returns a reactive stream of all homework mark metadata.
+     */
     fun getAll(): Flow<List<HomeworkMarkMetadata>> = homeworkMarkMetadataDao.getAllHomeworkMarkMetadata()
 
+    /**
+     * Returns a one-shot list of all homework mark metadata.
+     * Essential for initializing the [com.example.myapplication.util.HomeworkScoreEngine.HomeworkScoringContext].
+     */
     suspend fun getAllList(): List<HomeworkMarkMetadata> = homeworkMarkMetadataDao.getAllHomeworkMarkMetadataList()
 
+    /**
+     * Persists a new homework metadata entry.
+     */
     suspend fun insert(metadata: HomeworkMarkMetadata) {
         homeworkMarkMetadataDao.insert(metadata)
     }
 
+    /**
+     * Updates an existing homework metadata entry.
+     */
     suspend fun update(metadata: HomeworkMarkMetadata) {
         homeworkMarkMetadataDao.update(metadata)
     }
 
+    /**
+     * Deletes a specific metadata entry.
+     */
     suspend fun delete(metadata: HomeworkMarkMetadata) {
         homeworkMarkMetadataDao.delete(metadata)
     }
 
+    /**
+     * Clears all homework metadata from the system.
+     */
     suspend fun deleteAll() {
         homeworkMarkMetadataDao.deleteAll()
     }
 
+    /**
+     * Batch inserts a list of metadata entries.
+     */
     suspend fun insertAll(metadataList: List<HomeworkMarkMetadata>) {
         homeworkMarkMetadataDao.insertAll(metadataList)
     }
 
+    /**
+     * Atomically replaces all existing metadata with a new list.
+     */
     suspend fun replaceAll(metadataList: List<HomeworkMarkMetadata>) {
         homeworkMarkMetadataDao.replaceAll(metadataList)
     }

--- a/app/src/main/java/com/example/myapplication/data/QuizMarkTypeDao.kt
+++ b/app/src/main/java/com/example/myapplication/data/QuizMarkTypeDao.kt
@@ -10,32 +10,68 @@ import androidx.room.Transaction
 import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Data Access Object for [QuizMarkType] entities.
+ *
+ * This DAO provides the interface for persisting and querying the metadata that defines
+ * how granular quiz marks (e.g., "Correct", "Half Credit") are translated into numeric
+ * point values.
+ */
 @Dao
 interface QuizMarkTypeDao {
+    /**
+     * Inserts a single mark type. If a mark type with the same ID already exists,
+     * it will be replaced.
+     */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(quizMarkType: QuizMarkType)
 
+    /**
+     * Updates an existing mark type's configuration (e.g., changing its default points).
+     */
     @Update
     suspend fun update(quizMarkType: QuizMarkType)
 
+    /**
+     * Removes a mark type from the database.
+     */
     @Delete
     suspend fun delete(quizMarkType: QuizMarkType)
 
+    /**
+     * Observes all available mark types, sorted alphabetically by name.
+     */
     @Query("SELECT * FROM quiz_mark_types ORDER BY name ASC")
     fun getAllQuizMarkTypes(): Flow<List<QuizMarkType>>
 
+    /**
+     * Retrieves a one-shot list of all mark types.
+     */
     @Query("SELECT * FROM quiz_mark_types ORDER BY name ASC")
     suspend fun getAllQuizMarkTypesList(): List<QuizMarkType>
 
+    /**
+     * Retrieves a specific mark type by its unique database ID.
+     */
     @Query("SELECT * FROM quiz_mark_types WHERE id = :id")
     suspend fun getQuizMarkTypeById(id: Long): QuizMarkType?
 
+    /**
+     * Clears all mark type metadata from the database.
+     */
     @Query("DELETE FROM quiz_mark_types")
     suspend fun deleteAll()
 
+    /**
+     * Inserts multiple mark types in a single operation.
+     */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(markTypes: List<QuizMarkType>)
 
+    /**
+     * Atomically replaces the entire mark type library.
+     * This is commonly used during data synchronization or when resetting to default values.
+     */
     @Transaction
     suspend fun replaceAll(markTypes: List<QuizMarkType>) {
         deleteAll()

--- a/app/src/main/java/com/example/myapplication/data/QuizMarkTypeRepository.kt
+++ b/app/src/main/java/com/example/myapplication/data/QuizMarkTypeRepository.kt
@@ -4,30 +4,63 @@ import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Repository that coordinates access to [QuizMarkType] metadata.
+ *
+ * This repository serves as the single source of truth for the ViewModels and scoring
+ * engines regarding how quiz marks are defined.
+ *
+ * ### Scoring Heuristic:
+ * The application's scoring logic (see `QuizScoreEngine`) relies on a naming convention
+ * managed through this repository. It specifically scans for a mark type named **"Correct"**
+ * (case-insensitive) to establish the base point value for the quiz denominator.
+ */
 @Singleton
 class QuizMarkTypeRepository @Inject constructor(
     private val quizMarkTypeDao: QuizMarkTypeDao
 ) {
+    /**
+     * Returns a reactive stream of all available [QuizMarkType] definitions.
+     */
     fun getAll(): Flow<List<QuizMarkType>> = quizMarkTypeDao.getAllQuizMarkTypes()
 
+    /**
+     * Persists a new mark type definition.
+     */
     suspend fun insert(quizMarkType: QuizMarkType) {
         quizMarkTypeDao.insert(quizMarkType)
     }
 
+    /**
+     * Updates an existing mark type definition.
+     */
     suspend fun update(quizMarkType: QuizMarkType) {
         quizMarkTypeDao.update(quizMarkType)
     }
 
+    /**
+     * Deletes a mark type definition.
+     */
     suspend fun delete(quizMarkType: QuizMarkType) {
         quizMarkTypeDao.delete(quizMarkType)
     }
 
+    /**
+     * Returns a one-shot list of all [QuizMarkType] definitions.
+     * Useful for initializing scoring contexts in the background update pipeline.
+     */
     suspend fun getAllList(): List<QuizMarkType> = quizMarkTypeDao.getAllQuizMarkTypesList()
 
+    /**
+     * Batch inserts a list of mark type definitions.
+     */
     suspend fun insertAll(markTypes: List<QuizMarkType>) {
         markTypes.forEach { quizMarkTypeDao.insert(it) }
     }
 
+    /**
+     * Removes all mark type definitions from the database.
+     */
     suspend fun deleteAll() {
         quizMarkTypeDao.deleteAll()
     }


### PR DESCRIPTION
🔦 *The Blind Spot:* The application's scoring infrastructure, which relies on specific naming heuristics and normalized metadata mapping, was undocumented in the data layer, making it difficult for new developers to understand how raw logs translate into numeric grades.

💡 *The Insight:* I implemented comprehensive KDoc for the Assessment Metadata cluster (QuizMarkType and HomeworkMarkMetadata). This explicitly documents the "Correct" naming convention used by the scoring engines and explains the relational role these entities play in the broader assessment ecosystem.

📖 *Preview:*
```kotlin
/**
 * Repository that coordinates access to [QuizMarkType] metadata.
 * ...
 * ### Scoring Heuristic:
 * The application's scoring logic (see `QuizScoreEngine`) relies on a naming convention
 * managed through this repository. It specifically scans for a mark type named **"Correct"**
 * (case-insensitive) to establish the base point value for the quiz denominator.
 */
```

---
*PR created automatically by Jules for task [9296264208959938591](https://jules.google.com/task/9296264208959938591) started by @YMSeatt*