### PR TITLE
🌉 Bridge: Port Bulk Student Group Assignment from Python

### DIFF
--- a/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
+++ b/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.icons.filled.CheckCircleOutline
 import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.MoreVert
@@ -769,6 +770,7 @@ fun SeatingChartScreen(
                 editModeEnabled = editModeEnabled,
                 seatingChartViewModel = seatingChartViewModel,
                 settingsViewModel = settingsViewModel,
+                studentGroupsViewModel = studentGroupsViewModel,
                 onShowSaveLayout = { showSaveLayoutDialog = true },
                 onShowLoadLayout = { showLoadLayoutDialog = true },
                 onShowExport = { showExportDialog = true },
@@ -2337,6 +2339,7 @@ fun SeatingChartTopAppBar(
     editModeEnabled: Boolean,
     seatingChartViewModel: SeatingChartViewModel,
     settingsViewModel: SettingsViewModel,
+    studentGroupsViewModel: StudentGroupsViewModel,
     onShowSaveLayout: () -> Unit,
     onShowLoadLayout: () -> Unit,
     onShowExport: () -> Unit,
@@ -2473,25 +2476,62 @@ fun SeatingChartTopAppBar(
 
             // Behaviors Dropdown
             val behaviorTargetCount = if (selectMode) selectedItemIds.filter { it.type == ItemType.STUDENT }.size else if (selectedStudentUiItemForAction != null) 1 else 0
-            if (behaviorTargetCount > 0 && behaviorTypeNames.isNotEmpty()) {
-                var showQuickBehaviorMenu by remember { mutableStateOf(false) }
+            if (behaviorTargetCount > 0) {
+                if (behaviorTypeNames.isNotEmpty()) {
+                    var showQuickBehaviorMenu by remember { mutableStateOf(false) }
+                    Box {
+                        TextButton(onClick = { showQuickBehaviorMenu = true }) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(18.dp))
+                                Text("Log ($behaviorTargetCount)", modifier = Modifier.padding(start = 4.dp))
+                            }
+                        }
+                        DropdownMenu(
+                            expanded = showQuickBehaviorMenu,
+                            onDismissRequest = { showQuickBehaviorMenu = false }
+                        ) {
+                            behaviorTypeNames.forEach { type ->
+                                DropdownMenuItem(
+                                    text = { Text(type) },
+                                    onClick = {
+                                        onBehaviorLog(type)
+                                        showQuickBehaviorMenu = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // Groups Dropdown (Ported from Python bulk group assignment)
+                val groups by studentGroupsViewModel.allStudentGroups.collectAsState(initial = emptyList())
+                var showQuickGroupMenu by remember { mutableStateOf(false) }
                 Box {
-                    TextButton(onClick = { showQuickBehaviorMenu = true }) {
+                    TextButton(onClick = { showQuickGroupMenu = true }) {
                         Row(verticalAlignment = Alignment.CenterVertically) {
-                            Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(18.dp))
-                            Text("Log ($behaviorTargetCount)", modifier = Modifier.padding(start = 4.dp))
+                            Icon(Icons.Default.Group, contentDescription = null, modifier = Modifier.size(18.dp))
+                            Text("Group ($behaviorTargetCount)", modifier = Modifier.padding(start = 4.dp))
                         }
                     }
                     DropdownMenu(
-                        expanded = showQuickBehaviorMenu,
-                        onDismissRequest = { showQuickBehaviorMenu = false }
+                        expanded = showQuickGroupMenu,
+                        onDismissRequest = { showQuickGroupMenu = false }
                     ) {
-                        behaviorTypeNames.forEach { type ->
+                        DropdownMenuItem(
+                            text = { Text("No Group") },
+                            onClick = {
+                                val targets = if (selectMode) selectedItemIds.filter { it.type == ItemType.STUDENT }.map { it.id.toLong() } else listOfNotNull(selectedStudentUiItemForAction?.id?.toLong())
+                                seatingChartViewModel.assignStudentsToGroup(targets, null)
+                                showQuickGroupMenu = false
+                            }
+                        )
+                        groups.forEach { group ->
                             DropdownMenuItem(
-                                text = { Text(type) },
+                                text = { Text(group.name) },
                                 onClick = {
-                                    onBehaviorLog(type)
-                                    showQuickBehaviorMenu = false
+                                    val targets = if (selectMode) selectedItemIds.filter { it.type == ItemType.STUDENT }.map { it.id.toLong() } else listOfNotNull(selectedStudentUiItemForAction?.id?.toLong())
+                                    seatingChartViewModel.assignStudentsToGroup(targets, group.id)
+                                    showQuickGroupMenu = false
                                 }
                             )
                         }

--- a/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
@@ -2169,20 +2169,36 @@ class SeatingChartViewModel @Inject constructor(
     }
 
     fun assignStudentToGroup(studentId: Long, groupId: Long) {
-        viewModelScope.launch {
-            val student = getStudentForEditing(studentId) ?: return@launch
-            val updatedStudent = student.copy(groupId = groupId)
-            val command = UpdateStudentCommand(this@SeatingChartViewModel, student, updatedStudent)
-            executeCommand(command)
-        }
+        assignStudentsToGroup(listOf(studentId), groupId)
     }
 
     fun removeStudentFromGroup(studentId: Long) {
+        assignStudentsToGroup(listOf(studentId), null)
+    }
+
+    /**
+     * BOLT: Bulk student group assignment. Encapsulates multiple assignments into a single
+     * CompositeCommand to ensure atomic history updates and consistent undo/redo.
+     */
+    fun assignStudentsToGroup(studentIds: List<Long>, groupId: Long?) {
+        if (studentIds.isEmpty()) return
         viewModelScope.launch {
-            val student = getStudentForEditing(studentId) ?: return@launch
-            val updatedStudent = student.copy(groupId = null)
-            val command = UpdateStudentCommand(this@SeatingChartViewModel, student, updatedStudent)
-            executeCommand(command)
+            val commands = studentIds.mapNotNull { id ->
+                val student = getStudentForEditing(id)
+                if (student != null && student.groupId != groupId) {
+                    val updatedStudent = student.copy(groupId = groupId)
+                    UpdateStudentCommand(this@SeatingChartViewModel, student, updatedStudent)
+                } else {
+                    null
+                }
+            }
+            if (commands.isNotEmpty()) {
+                val groupName = if (groupId != null) {
+                    allGroups.value.find { it.id == groupId }?.name ?: "Group $groupId"
+                } else "No Group"
+                val compositeCommand = CompositeCommand(commands, "Assign ${commands.size} student(s) to $groupName")
+                executeCommand(compositeCommand)
+            }
         }
     }
 


### PR DESCRIPTION
I have ported the "Bulk Student Group Assignment" feature from the Python desktop application to the Android app. This allows teachers to select multiple students and assign them to a group (or unassign them) in a single action. The implementation uses a `CompositeCommand` to ensure that this bulk action can be undone or redone in one step, preserving logical parity with the Python blueprint. The UI has been updated to include a "Group" menu in the top app bar when students are selected.

---
*PR created automatically by Jules for task [7026442563302621129](https://jules.google.com/task/7026442563302621129) started by @YMSeatt*