### PR TITLE
Ghost: Neural Mood Board Implementation

### DIFF
--- a/.jules/ghost_todo.md
+++ b/.jules/ghost_todo.md
@@ -1,10 +1,10 @@
 # 👻 Ghost Android Backlog
-- [ ] Idea: Add Neural "Mood Board" visualization
 - [ ] Idea: Implement "Ghost Link" proximity-based pairing
 
 ## 🚧 Active Construction
 
 ## ✅ Completed Enhancements
+- [DONE] 2028-08-03: Neural Mood Board - Atmospheric mood visualization in `/labs/ghost/mood/`
 - [DONE] 2028-08-01: Ghost Mirror - Spatial perspective flipping in `/labs/ghost/mirror/`
 - [DONE] 2028-07-30: Ghost Pulse - Temporal resonance visualization in `/labs/ghost/pulse/`
 - [DONE] 2028-07-28: Ghost Beacon - Data-driven student picker & volumetric beacon in `/labs/ghost/beacon/`

--- a/app/src/main/java/com/example/myapplication/labs/ghost/GhostConfig.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/GhostConfig.kt
@@ -234,4 +234,7 @@ object GhostConfig {
 
     /** Enables "Ghost Mirror" spatial perspective flipping. */
     const val MIRROR_MODE_ENABLED = true
+
+    /** Enables the "Neural Mood Board" atmospheric visualization. */
+    const val MOOD_MODE_ENABLED = true
 }

--- a/app/src/main/java/com/example/myapplication/labs/ghost/hub/GhostHubLayer.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/hub/GhostHubLayer.kt
@@ -100,6 +100,9 @@ fun GhostHubLayer(
             if (GhostConfig.GHOST_MODE_ENABLED && GhostConfig.MIRROR_MODE_ENABLED) {
                 add(GhostAction("MIRROR", Icons.Default.Flip, "Ghost Mirror"))
             }
+            if (GhostConfig.GHOST_MODE_ENABLED && GhostConfig.MOOD_MODE_ENABLED) {
+                add(GhostAction("MOOD", Icons.Default.AutoAwesome, "Neural Mood"))
+            }
         }
     }
 

--- a/app/src/main/java/com/example/myapplication/labs/ghost/mood/GhostMoodEngine.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/mood/GhostMoodEngine.kt
@@ -1,0 +1,146 @@
+package com.example.myapplication.labs.ghost.mood
+
+import com.example.myapplication.data.BehaviorEvent
+import com.example.myapplication.data.HomeworkLog
+import com.example.myapplication.data.QuizLog
+
+/**
+ * GhostMoodEngine: Analyzes classroom data to determine "mood" states.
+ *
+ * This engine synthesizes behavioral and academic data into organic "mood" parameters
+ * used for atmospheric visualization.
+ *
+ * BOLT ⚡ Optimization: Uses manual index-based loops and O(N) single-pass analysis
+ * to eliminate iterator allocations and minimize GC pressure.
+ */
+object GhostMoodEngine {
+
+    enum class MoodState {
+        CALM,       // Stable, balanced activity
+        FOCUSED,    // High academic engagement, low behavioral turbulence
+        TURBULENT,  // High frequency of negative logs or rapid changes
+        ENERGETIC   // High frequency of positive logs
+    }
+
+    data class StudentMood(
+        val studentId: Long,
+        val state: MoodState,
+        val intensity: Float, // 0.0 to 1.0
+        val valence: Float    // -1.0 (Negative) to 1.0 (Positive)
+    )
+
+    data class ClassroomMood(
+        val aggregateState: MoodState,
+        val collectiveIntensity: Float,
+        val collectiveValence: Float,
+        val stability: Float // 0.0 (Chaotic) to 1.0 (Stable)
+    )
+
+    /**
+     * Calculates the mood for each student based on recent events.
+     *
+     * @param students List of student IDs.
+     * @param behaviorLogs Map of student IDs to their behavior events.
+     * @param quizLogs Map of student IDs to their quiz results.
+     * @param homeworkLogs Map of student IDs to their homework logs.
+     * @param timeWindow The window (in ms) to consider for "recent" behavior activity.
+     */
+    fun calculateStudentMoods(
+        students: List<Long>,
+        behaviorLogs: Map<Long, List<BehaviorEvent>>,
+        quizLogs: Map<Long, List<QuizLog>>,
+        homeworkLogs: Map<Long, List<HomeworkLog>>,
+        timeWindow: Long = 15 * 60 * 1000L // 15 minutes
+    ): List<StudentMood> {
+        val now = System.currentTimeMillis()
+        val moods = ArrayList<StudentMood>(students.size)
+
+        for (i in 0 until students.size) {
+            val studentId = students[i]
+            val bLogs = behaviorLogs[studentId]
+            val qLogs = quizLogs[studentId]
+            val hLogs = homeworkLogs[studentId]
+
+            var negCount = 0
+            var posCount = 0
+            var recentBehaviorCount = 0
+
+            if (bLogs != null) {
+                for (j in 0 until bLogs.size) {
+                    val log = bLogs[j]
+                    if (now - log.timestamp < timeWindow) {
+                        recentBehaviorCount++
+                        if (log.type.contains("Negative", ignoreCase = true)) {
+                            negCount++
+                        } else {
+                            posCount++
+                        }
+                    }
+                }
+            }
+
+            val quizCount = qLogs?.size ?: 0
+            val hwCount = hLogs?.size ?: 0
+            val academicIntensity = (quizCount + hwCount).toFloat() / 10f
+            val behaviorIntensity = recentBehaviorCount.toFloat() / 5f
+            val intensity = (academicIntensity + behaviorIntensity).coerceIn(0.1f, 1.0f)
+
+            val valence = if (recentBehaviorCount > 0) {
+                (posCount - negCount).toFloat() / recentBehaviorCount.toFloat()
+            } else 0f
+
+            val state = when {
+                negCount > posCount -> MoodState.TURBULENT
+                academicIntensity > 0.5f && negCount == 0 -> MoodState.FOCUSED
+                posCount > 2 -> MoodState.ENERGETIC
+                else -> MoodState.CALM
+            }
+
+            moods.add(StudentMood(studentId, state, intensity, valence.coerceIn(-1f, 1f)))
+        }
+
+        return moods
+    }
+
+    /**
+     * Calculates the overall classroom mood based on student moods.
+     */
+    fun calculateClassroomMood(studentMoods: List<StudentMood>): ClassroomMood {
+        if (studentMoods.isEmpty()) {
+            return ClassroomMood(MoodState.CALM, 0.2f, 0f, 1.0f)
+        }
+
+        var totalIntensity = 0f
+        var totalValence = 0f
+        var turbulentCount = 0
+        var focusedCount = 0
+        var energeticCount = 0
+
+        for (i in 0 until studentMoods.size) {
+            val mood = studentMoods[i]
+            totalIntensity += mood.intensity
+            totalValence += mood.valence
+            when (mood.state) {
+                MoodState.TURBULENT -> turbulentCount++
+                MoodState.FOCUSED -> focusedCount++
+                MoodState.ENERGETIC -> energeticCount++
+                else -> {}
+            }
+        }
+
+        val count = studentMoods.size.toFloat()
+        val avgIntensity = totalIntensity / count
+        val avgValence = totalValence / count
+
+        val state = when {
+            turbulentCount > studentMoods.size * 0.2 -> MoodState.TURBULENT
+            focusedCount > studentMoods.size * 0.4 -> MoodState.FOCUSED
+            energeticCount > studentMoods.size * 0.3 -> MoodState.ENERGETIC
+            else -> MoodState.CALM
+        }
+
+        val stability = 1.0f - (turbulentCount.toFloat() / count)
+
+        return ClassroomMood(state, avgIntensity, avgValence, stability)
+    }
+}

--- a/app/src/main/java/com/example/myapplication/labs/ghost/mood/GhostMoodLayer.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/mood/GhostMoodLayer.kt
@@ -1,0 +1,79 @@
+package com.example.myapplication.labs.ghost.mood
+
+import android.graphics.RuntimeShader
+import android.os.Build
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ShaderBrush
+import com.example.myapplication.labs.ghost.GhostConfig
+
+/**
+ * GhostMoodLayer: A high-performance visualization layer for the Neural Mood Board.
+ *
+ * This layer renders the collective mood of the classroom as an organic, atmospheric
+ * background on the seating chart.
+ *
+ * BOLT ⚡ Optimization: Uses zero-allocation rendering by hoisting the [RuntimeShader]
+ * and [ShaderBrush] and updating uniforms directly in the [Canvas] block.
+ */
+@Composable
+fun GhostMoodLayer(
+    classroomMood: GhostMoodEngine.ClassroomMood,
+    isVisible: Boolean
+) {
+    if (!isVisible || !GhostConfig.GHOST_MODE_ENABLED) return
+
+    val infiniteTransition = rememberInfiniteTransition(label = "ghost_mood_time")
+    val time by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 6.28f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(10000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "time"
+    )
+
+    // Smoothly animate mood parameters to prevent visual jumps
+    val animatedIntensity by animateFloatAsState(classroomMood.collectiveIntensity, label = "intensity")
+    val animatedValence by animateFloatAsState(classroomMood.collectiveValence, label = "valence")
+    val animatedStability by animateFloatAsState(classroomMood.stability, label = "stability")
+
+    val primaryColor = when (classroomMood.aggregateState) {
+        GhostMoodEngine.MoodState.TURBULENT -> Color.Red
+        GhostMoodEngine.MoodState.FOCUSED -> Color.Cyan
+        GhostMoodEngine.MoodState.ENERGETIC -> Color.Yellow
+        GhostMoodEngine.MoodState.CALM -> Color.Green
+    }
+
+    val secondaryColor = when (classroomMood.aggregateState) {
+        GhostMoodEngine.MoodState.TURBULENT -> Color(0xFF6200EE) // Purple
+        GhostMoodEngine.MoodState.FOCUSED -> Color.Blue
+        GhostMoodEngine.MoodState.ENERGETIC -> Color.Magenta
+        GhostMoodEngine.MoodState.CALM -> Color(0xFF004D40) // Dark Teal
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        val shader = remember { RuntimeShader(GhostMoodShader.NEURAL_MOOD_BOARD) }
+        val brush = remember(shader) { ShaderBrush(shader) }
+
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            shader.setFloatUniform("iResolution", size.width, size.height)
+            shader.setFloatUniform("iTime", time)
+            shader.setFloatUniform("iIntensity", animatedIntensity)
+            shader.setFloatUniform("iValence", animatedValence)
+            shader.setFloatUniform("iStability", animatedStability)
+
+            shader.setColorUniform("iColorPrimary",
+                android.graphics.Color.valueOf(primaryColor.red, primaryColor.green, primaryColor.blue, primaryColor.alpha))
+            shader.setColorUniform("iColorSecondary",
+                android.graphics.Color.valueOf(secondaryColor.red, secondaryColor.green, secondaryColor.blue, secondaryColor.alpha))
+
+            drawRect(brush = brush)
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapplication/labs/ghost/mood/GhostMoodShader.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/mood/GhostMoodShader.kt
@@ -1,0 +1,57 @@
+package com.example.myapplication.labs.ghost.mood
+
+import org.intellij.lang.annotations.Language
+
+/**
+ * GhostMoodShader: AGSL shaders for the Neural Mood Board.
+ *
+ * This shader visualizes the collective classroom mood as an organic, shifting color field
+ * using a combination of Voronoi-like noise and smooth color blending.
+ */
+object GhostMoodShader {
+
+    @Language("AGSL")
+    const val NEURAL_MOOD_BOARD = """
+        uniform float2 iResolution;
+        uniform float iTime;
+        uniform float iIntensity;
+        uniform float iValence;
+        uniform float iStability;
+        uniform half4 iColorPrimary;
+        uniform half4 iColorSecondary;
+
+        float hash(float2 p) {
+            return fract(sin(dot(p, float2(127.1, 311.7))) * 43758.5453123);
+        }
+
+        float noise(float2 p) {
+            float2 i = floor(p);
+            float2 f = fract(p);
+            float2 u = f * f * (3.0 - 2.0 * f);
+            return mix(mix(hash(i + float2(0.0, 0.0)), hash(i + float2(1.0, 0.0)), u.x),
+                       mix(hash(i + float2(0.0, 1.0)), hash(i + float2(1.0, 1.0)), u.x), u.y);
+        }
+
+        half4 main(float2 fragCoord) {
+            float2 uv = fragCoord / iResolution.xy;
+            float2 p = uv * 3.0;
+
+            // Animating noise for organic movement
+            float n1 = noise(p + iTime * 0.2 * iStability);
+            float n2 = noise(p * 2.0 - iTime * 0.1 * iStability);
+            float combinedNoise = (n1 + n2 * 0.5) / 1.5;
+
+            // Base color blending based on valence
+            half4 moodColor = mix(iColorSecondary, iColorPrimary, iValence * 0.5 + 0.5);
+
+            // Adding subtle turbulence for low stability
+            float turbulence = (1.0 - iStability) * noise(p * 10.0 + iTime);
+            moodColor.rgb += turbulence * 0.1;
+
+            // Final alpha based on intensity and noise to create organic edges
+            float alpha = iIntensity * combinedNoise * 0.6;
+
+            return half4(moodColor.rgb, alpha);
+        }
+    """
+}

--- a/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
+++ b/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
@@ -125,6 +125,8 @@ import com.example.myapplication.labs.ghost.GhostSpectraLayer
 import com.example.myapplication.labs.ghost.GhostFluxLayer
 import com.example.myapplication.labs.ghost.GhostSingularityLayer
 import com.example.myapplication.labs.ghost.GhostAuroraLayer
+import com.example.myapplication.labs.ghost.mood.GhostMoodEngine
+import com.example.myapplication.labs.ghost.mood.GhostMoodLayer
 import com.example.myapplication.labs.ghost.silhouette.GhostSilhouetteLayer
 import com.example.myapplication.labs.ghost.ion.GhostIonLayer
 import com.example.myapplication.labs.ghost.sync.GhostSyncLayer
@@ -345,6 +347,7 @@ fun SeatingChartScreen(
     var isSpectraActive by remember { mutableStateOf(false) }
     var isFluxActive by remember { mutableStateOf(false) }
     var isAuroraActive by remember { mutableStateOf(false) }
+    var isMoodActive by remember { mutableStateOf(false) }
     var isNebulaActive by remember { mutableStateOf(false) }
     var isPulseActive by remember { mutableStateOf(false) }
     var isLensActive by remember { mutableStateOf(false) }
@@ -1295,6 +1298,27 @@ fun SeatingChartScreen(
                 )
             }
 
+            if (GhostConfig.GHOST_MODE_ENABLED && GhostConfig.MOOD_MODE_ENABLED && isMoodActive) {
+                val studentMoods = remember(students, allBehaviorEvents, allQuizLogs, allHomeworkLogs) {
+                    val behaviorMap = allBehaviorEvents.groupBy { it.studentId }
+                    val quizMap = allQuizLogs.groupBy { it.studentId }
+                    val homeworkMap = allHomeworkLogs.groupBy { it.studentId }
+                    GhostMoodEngine.calculateStudentMoods(
+                        students.map { it.id.toLong() },
+                        behaviorMap,
+                        quizMap,
+                        homeworkMap
+                    )
+                }
+                val classroomMood = remember(studentMoods) {
+                    GhostMoodEngine.calculateClassroomMood(studentMoods)
+                }
+                GhostMoodLayer(
+                    classroomMood = classroomMood,
+                    isVisible = isMoodActive
+                )
+            }
+
             if (GhostConfig.GHOST_MODE_ENABLED && GhostConfig.NEBULA_MODE_ENABLED && isNebulaActive) {
                 GhostNebulaLayer(
                     students = students,
@@ -2088,6 +2112,7 @@ fun SeatingChartScreen(
                     onActionSelected = { action ->
                         when (action.id) {
                             "HUD" -> isHudActive = !isHudActive
+                            "MOOD" -> isMoodActive = !isMoodActive
                             "VISION" -> isVisionActive = !isVisionActive
                             "PHANTASM" -> isPhantasmActive = !isPhantasmActive
                             "SPECTRA" -> isSpectraActive = !isSpectraActive

--- a/app/src/test/java/com/example/myapplication/labs/ghost/mood/GhostMoodEngineTest.kt
+++ b/app/src/test/java/com/example/myapplication/labs/ghost/mood/GhostMoodEngineTest.kt
@@ -1,0 +1,66 @@
+package com.example.myapplication.labs.ghost.mood
+
+import com.example.myapplication.data.BehaviorEvent
+import org.junit.Assert.*
+import org.junit.Test
+
+class GhostMoodEngineTest {
+
+    @Test
+    fun testCalculateStudentMoods_Calm() {
+        val students = listOf(1L)
+        val behaviorLogs = mapOf(1L to emptyList<BehaviorEvent>())
+        val moods = GhostMoodEngine.calculateStudentMoods(students, behaviorLogs, emptyMap(), emptyMap())
+
+        assertEquals(1, moods.size)
+        assertEquals(GhostMoodEngine.MoodState.CALM, moods[0].state)
+        assertEquals(0.1f, moods[0].intensity, 0.01f)
+        assertEquals(0f, moods[0].valence, 0.01f)
+    }
+
+    @Test
+    fun testCalculateStudentMoods_Turbulent() {
+        val students = listOf(1L)
+        val now = System.currentTimeMillis()
+        val behaviorLogs = mapOf(
+            1L to listOf(
+                BehaviorEvent(1, 1L, "Negative (Talking)", now - 1000, null)
+            )
+        )
+        val moods = GhostMoodEngine.calculateStudentMoods(students, behaviorLogs, emptyMap(), emptyMap())
+
+        assertEquals(GhostMoodEngine.MoodState.TURBULENT, moods[0].state)
+        assertTrue(moods[0].valence < 0f)
+    }
+
+    @Test
+    fun testCalculateStudentMoods_Energetic() {
+        val students = listOf(1L)
+        val now = System.currentTimeMillis()
+        val behaviorLogs = mapOf(
+            1L to listOf(
+                BehaviorEvent(1, 1L, "Positive (Participation)", now - 1000, null),
+                BehaviorEvent(2, 1L, "Positive (Helpful)", now - 2000, null),
+                BehaviorEvent(3, 1L, "Positive (Focused)", now - 3000, null)
+            )
+        )
+        val moods = GhostMoodEngine.calculateStudentMoods(students, behaviorLogs, emptyMap(), emptyMap())
+
+        assertEquals(GhostMoodEngine.MoodState.ENERGETIC, moods[0].state)
+        assertTrue(moods[0].valence > 0f)
+    }
+
+    @Test
+    fun testCalculateClassroomMood_Aggregate() {
+        val studentMoods = listOf(
+            GhostMoodEngine.StudentMood(1L, GhostMoodEngine.MoodState.TURBULENT, 0.8f, -0.8f),
+            GhostMoodEngine.StudentMood(2L, GhostMoodEngine.MoodState.TURBULENT, 0.9f, -0.9f),
+            GhostMoodEngine.StudentMood(3L, GhostMoodEngine.MoodState.CALM, 0.2f, 0f)
+        )
+
+        val classroomMood = GhostMoodEngine.calculateClassroomMood(studentMoods)
+
+        assertEquals(GhostMoodEngine.MoodState.TURBULENT, classroomMood.aggregateState)
+        assertTrue(classroomMood.stability < 1.0f)
+    }
+}


### PR DESCRIPTION
Implemented the "Neural Mood Board" experiment for Ghost Lab. This feature synthesizes student behavior and academic metrics into a high-fidelity atmospheric visualization on the seating chart.

Key components:
- **GhostMoodEngine**: Performs $O(N)$ single-pass analysis of logs to determine mood states (Calm, Focused, Turbulent, Energetic).
- **GhostMoodShader**: An AGSL-backed organic noise shader that shifts colors based on classroom valence and intensity.
- **GhostMoodLayer**: A performant Compose layer that renders the mood board in the seating chart background.
- **Integration**: Added to the radial Ghost Hub menu and gated by the `MOOD_MODE_ENABLED` flag.

Adheres to Ghost Lab's architectural standards for native Android R&D and BOLT performance optimizations.

---
*PR created automatically by Jules for task [14906823108158921706](https://jules.google.com/task/14906823108158921706) started by @YMSeatt*