### PR TITLE
📜 Scribe: [Docs] Document System Behavior infrastructure

### DIFF
--- a/app/src/main/java/com/example/myapplication/data/README.md
+++ b/app/src/main/java/com/example/myapplication/data/README.md
@@ -26,6 +26,9 @@ The data model is organized into three primary clusters:
     *   **CustomHomeworkType**: Used to group and filter assignments into categories like "Reading", "Project", or "Lab".
     *   **CustomHomeworkStatus**: Defines rich status labels (e.g., "Submitted Late", "Missing", "Redo Required") to provide context beyond binary completion.
 
+5.  **System-Level Metadata (Standardized Feedback)**:
+    *   **SystemBehavior**: Provides a set of "hardcoded" feedback categories (e.g., "Participating", "Disruptive") that ensure global reporting consistency across all classrooms. These are typically immutable by the teacher and are established during system initialization.
+
 ## 🧪 Normalized Assignment Model (Modern) vs. Legacy Log Model
 
 The application is currently transitioning from a flat, log-based history to a normalized, template-based assignment system.

--- a/app/src/main/java/com/example/myapplication/data/SystemBehavior.kt
+++ b/app/src/main/java/com/example/myapplication/data/SystemBehavior.kt
@@ -4,6 +4,20 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import kotlinx.serialization.Serializable
 
+/**
+ * Represents a standardized, system-level feedback option for student behavior.
+ *
+ * Unlike [CustomBehavior], which are defined by individual teachers, System Behaviors
+ * provide a consistent set of "hardcoded" feedback categories that can be used across
+ * different classrooms for global reporting and analytics.
+ *
+ * These options are typically populated during database initialization or migrations
+ * (e.g., Migration v22) and serve as the baseline for the behavior logging UI.
+ *
+ * @property id Unique identifier for the system behavior.
+ * @property name The short label for the behavior (e.g., "Participating", "Disruptive").
+ * @property description A more detailed explanation of what the behavior entails.
+ */
 @Serializable
 @Entity(tableName = "system_behaviors")
 data class SystemBehavior(

--- a/app/src/main/java/com/example/myapplication/data/SystemBehaviorDao.kt
+++ b/app/src/main/java/com/example/myapplication/data/SystemBehaviorDao.kt
@@ -5,11 +5,31 @@ import androidx.room.Insert
 import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Data Access Object for standardized [SystemBehavior] options.
+ *
+ * This DAO manages the baseline feedback categories used in the behavior entry UI.
+ * System behaviors are typically read-only from the user's perspective, providing
+ * a fixed set of options for consistent reporting.
+ */
 @Dao
 interface SystemBehaviorDao {
+    /**
+     * Retrieves all available system-level behavior options as a reactive [Flow].
+     *
+     * This stream is observed by the UI to populate the initial feedback options
+     * in the behavior logging menus.
+     */
     @Query("SELECT * FROM system_behaviors")
     fun getAllSystemBehaviors(): Flow<List<SystemBehavior>>
 
+    /**
+     * Inserts a new system behavior option into the database.
+     *
+     * This method is primarily used during database bootstrapping, factory resets,
+     * or room migrations (e.g., version 22) to establish the standardized set
+     * of feedback categories.
+     */
     @Insert
     suspend fun insert(systemBehavior: SystemBehavior)
 }


### PR DESCRIPTION
🔦 **The Blind Spot:** The `SystemBehavior` cluster (entity and DAO) was introduced in Database Migration v22 but lacked any documentation explaining its purpose or its relationship to user-defined `CustomBehavior` models.

💡 **The Insight:** I implemented comprehensive KDocs and README updates that define `SystemBehavior` as the infrastructure for "Standardized Feedback"—immutable categories that ensure consistency across classrooms for global reporting.

📖 **Preview:**
- **SystemBehavior.kt**: Clarifies that these are "hardcoded" feedback options.
- **SystemBehaviorDao.kt**: Documents the reactive `Flow` stream used for logging UI.
- **Data README**: Adds a new "System-Level Metadata" section to the architectural overview.

---
*PR created automatically by Jules for task [4278929853769135269](https://jules.google.com/task/4278929853769135269) started by @YMSeatt*