### PR TITLE
⚡ Bolt: [Optimization] in JsonImporter.kt

### DIFF
--- a/app/src/main/java/com/example/myapplication/data/HomeworkTemplateDao.kt
+++ b/app/src/main/java/com/example/myapplication/data/HomeworkTemplateDao.kt
@@ -24,6 +24,12 @@ interface HomeworkTemplateDao {
     suspend fun insert(homeworkTemplate: HomeworkTemplate)
 
     /**
+     * Bulk inserts or replaces multiple [HomeworkTemplate] records.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(homeworkTemplates: List<HomeworkTemplate>)
+
+    /**
      * Updates an existing homework template's metadata or scoring structure.
      */
     @Update

--- a/app/src/main/java/com/example/myapplication/data/StudentGroupDao.kt
+++ b/app/src/main/java/com/example/myapplication/data/StudentGroupDao.kt
@@ -49,6 +49,12 @@ interface StudentGroupDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(studentGroup: StudentGroup): Long
 
+    /**
+     * Bulk inserts or replaces multiple [StudentGroup] records.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(studentGroups: List<StudentGroup>): List<Long>
+
     @Update
     suspend fun update(studentGroup: StudentGroup)
 

--- a/app/src/main/java/com/example/myapplication/data/importer/JsonImporter.kt
+++ b/app/src/main/java/com/example/myapplication/data/importer/JsonImporter.kt
@@ -2,6 +2,8 @@ package com.example.myapplication.data.importer
 
 import android.content.Context
 import android.net.Uri
+import androidx.room.withTransaction
+import com.example.myapplication.data.AppDatabase
 import com.example.myapplication.data.BehaviorEvent
 import com.example.myapplication.data.BehaviorEventDao
 import com.example.myapplication.data.CustomBehavior
@@ -59,6 +61,7 @@ import javax.inject.Singleton
 @Singleton
 class JsonImporter @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val db: AppDatabase,
     private val studentDao: StudentDao,
     private val furnitureDao: FurnitureDao,
     private val behaviorEventDao: BehaviorEventDao,
@@ -105,7 +108,7 @@ class JsonImporter @Inject constructor(
     private suspend fun importHomeworkTemplates(uri: Uri) {
         val content = readFileContent(uri)
         val pythonData = json.decodeFromString<List<PythonHomeworkTemplate>>(content)
-        pythonData.forEach { pythonTemplate ->
+        val templatesToInsert = pythonData.map { pythonTemplate ->
             val steps = pythonTemplate.steps.map { pythonStep ->
                 HomeworkMarkStep(
                     label = pythonStep.label,
@@ -118,12 +121,12 @@ class JsonImporter @Inject constructor(
                     maxValue = pythonStep.maxValue
                 )
             }
-            val homeworkTemplate = HomeworkTemplate(
+            HomeworkTemplate(
                 name = pythonTemplate.name,
                 marksData = json.encodeToString(steps)
             )
-            homeworkTemplateDao.insert(homeworkTemplate)
         }
+        homeworkTemplateDao.insertAll(templatesToInsert)
     }
 
     /**
@@ -159,118 +162,123 @@ class JsonImporter @Inject constructor(
         val content = readFileContent(uri)
         val pythonData = json.decodeFromString<PythonClassroomData>(content)
 
-        // Import students
-        pythonData.students.forEach { (stringId, pythonStudent) ->
-            val student = Student(
-                stringId = stringId,
-                firstName = pythonStudent.firstName,
-                lastName = pythonStudent.lastName,
-                nickname = pythonStudent.nickname,
-                gender = pythonStudent.gender,
-                xPosition = pythonStudent.x.toFloat(),
-                yPosition = pythonStudent.y.toFloat(),
-                customWidth = pythonStudent.styleOverrides.width?.toInt(),
-                customHeight = pythonStudent.styleOverrides.height?.toInt(),
-                customBackgroundColor = pythonStudent.styleOverrides.fillColor,
-                customOutlineColor = pythonStudent.styleOverrides.outlineColor,
-                customTextColor = pythonStudent.styleOverrides.textColor,
-                groupId = studentGroupDao.getGroupByName(pythonStudent.groupId)?.id
-            )
-            studentDao.insert(student)
-        }
+        db.withTransaction {
+            // BOLT: Pre-fetch all student groups into a map for O(1) lookup during student import.
+            val studentGroups = studentGroupDao.getAllStudentGroupsList().associateBy { it.name }
 
-        // Import furniture
-        pythonData.furniture.forEach { (stringId, pythonFurniture) ->
-            val furniture = Furniture(
-                stringId = stringId,
-                name = pythonFurniture.name,
-                type = pythonFurniture.type,
-                xPosition = pythonFurniture.x.toFloat(),
-                yPosition = pythonFurniture.y.toFloat(),
-                width = pythonFurniture.width.toInt(),
-                height = pythonFurniture.height.toInt(),
-                fillColor = pythonFurniture.fillColor,
-                outlineColor = pythonFurniture.outlineColor
-            )
-            furnitureDao.insert(furniture)
-        }
-
-        // Import behavior logs
-        pythonData.behaviorLog.forEach { pythonBehaviorLog ->
-            val student = studentDao.getStudentByStringId(pythonBehaviorLog.studentId)
-            if (student != null) {
-                val behaviorEvent = BehaviorEvent(
-                    studentId = student.id,
-                    type = pythonBehaviorLog.behavior,
-                    timestamp = LocalDateTime.parse(pythonBehaviorLog.timestamp)
-                        .toEpochSecond(ZoneOffset.UTC),
-                    comment = pythonBehaviorLog.comment
+            // Pass 1: Import Students
+            val studentEntries = pythonData.students.entries.toList()
+            val studentsToInsert = studentEntries.map { (stringId, pythonStudent) ->
+                Student(
+                    stringId = stringId,
+                    firstName = pythonStudent.firstName,
+                    lastName = pythonStudent.lastName,
+                    nickname = pythonStudent.nickname,
+                    gender = pythonStudent.gender,
+                    xPosition = pythonStudent.x.toFloat(),
+                    yPosition = pythonStudent.y.toFloat(),
+                    customWidth = pythonStudent.styleOverrides.width?.toInt(),
+                    customHeight = pythonStudent.styleOverrides.height?.toInt(),
+                    customBackgroundColor = pythonStudent.styleOverrides.fillColor,
+                    customOutlineColor = pythonStudent.styleOverrides.outlineColor,
+                    customTextColor = pythonStudent.styleOverrides.textColor,
+                    groupId = studentGroups[pythonStudent.groupId]?.id
                 )
-                behaviorEventDao.insert(behaviorEvent)
             }
-        }
+            val insertedStudentIds = studentDao.insertAll(studentsToInsert)
+            // Create a mapping from Python-style ID (from input Map key) to local Long ID for O(1) resolution.
+            val studentIdMap = studentEntries.indices.associate { i -> studentEntries[i].key to insertedStudentIds[i] }
 
-        // Import homework logs
-        pythonData.homeworkLog.forEach { pythonHomeworkLog ->
-            val student = studentDao.getStudentByStringId(pythonHomeworkLog.studentId)
-            if (student != null) {
-                val homeworkLog = HomeworkLog(
-                    studentId = student.id,
-                    assignmentName = pythonHomeworkLog.homeworkType,
-                    status = pythonHomeworkLog.behavior,
-                    loggedAt = LocalDateTime.parse(pythonHomeworkLog.timestamp)
-                        .toEpochSecond(ZoneOffset.UTC),
-                    comment = pythonHomeworkLog.comment,
-                    marksData = pythonHomeworkLog.homeworkDetails?.let { json.encodeToString(it) }
+            // Pass 2: Import Furniture
+            val furnitureToInsert = pythonData.furniture.map { (stringId, pythonFurniture) ->
+                Furniture(
+                    stringId = stringId,
+                    name = pythonFurniture.name,
+                    type = pythonFurniture.type,
+                    xPosition = pythonFurniture.x.toFloat(),
+                    yPosition = pythonFurniture.y.toFloat(),
+                    width = pythonFurniture.width.toInt(),
+                    height = pythonFurniture.height.toInt(),
+                    fillColor = pythonFurniture.fillColor,
+                    outlineColor = pythonFurniture.outlineColor
                 )
-                homeworkLogDao.insert(homeworkLog)
             }
+            furnitureDao.insertAll(furnitureToInsert)
+
+            // Pass 3: Import Behavior Logs
+            val behaviorEventsToInsert = pythonData.behaviorLog.mapNotNull { pythonBehaviorLog ->
+                studentIdMap[pythonBehaviorLog.studentId]?.let { localId ->
+                    BehaviorEvent(
+                        studentId = localId,
+                        type = pythonBehaviorLog.behavior,
+                        timestamp = LocalDateTime.parse(pythonBehaviorLog.timestamp)
+                            .toEpochSecond(ZoneOffset.UTC),
+                        comment = pythonBehaviorLog.comment
+                    )
+                }
+            }
+            behaviorEventDao.insertAll(behaviorEventsToInsert)
+
+            // Pass 4: Import Homework Logs
+            val homeworkLogsToInsert = pythonData.homeworkLog.mapNotNull { pythonHomeworkLog ->
+                studentIdMap[pythonHomeworkLog.studentId]?.let { localId ->
+                    HomeworkLog(
+                        studentId = localId,
+                        assignmentName = pythonHomeworkLog.homeworkType,
+                        status = pythonHomeworkLog.behavior,
+                        loggedAt = LocalDateTime.parse(pythonHomeworkLog.timestamp)
+                            .toEpochSecond(ZoneOffset.UTC),
+                        comment = pythonHomeworkLog.comment,
+                        marksData = pythonHomeworkLog.homeworkDetails?.let { json.encodeToString(it) }
+                    )
+                }
+            }
+            homeworkLogDao.insertAll(homeworkLogsToInsert)
         }
     }
 
     private suspend fun importStudentGroups(uri: Uri) {
         val content = readFileContent(uri)
         val pythonData = json.decodeFromString<Map<String, PythonStudentGroup>>(content)
-        pythonData.values.forEach { pythonStudentGroup ->
-            val studentGroup = StudentGroup(
+        val groupsToInsert = pythonData.values.map { pythonStudentGroup ->
+            StudentGroup(
                 name = pythonStudentGroup.name,
                 color = pythonStudentGroup.color
             )
-            studentGroupDao.insert(studentGroup)
         }
+        studentGroupDao.insertAll(groupsToInsert)
     }
 
     private suspend fun importCustomBehaviors(uri: Uri) {
         val content = readFileContent(uri)
         val pythonData = json.decodeFromString<List<PythonCustomBehavior>>(content)
-        pythonData.forEach { pythonCustomBehavior ->
-            val customBehavior = CustomBehavior(
+        val behaviorsToInsert = pythonData.map { pythonCustomBehavior ->
+            CustomBehavior(
                 name = pythonCustomBehavior.name
             )
-            customBehaviorDao.insert(customBehavior)
         }
+        customBehaviorDao.insertAll(behaviorsToInsert)
     }
 
     private suspend fun importCustomHomeworkStatuses(uri: Uri) {
         val content = readFileContent(uri)
         val pythonData = json.decodeFromString<List<PythonCustomHomeworkStatus>>(content)
-        pythonData.forEach { pythonCustomHomeworkStatus ->
-            val customHomeworkStatus = CustomHomeworkStatus(
+        val statusesToInsert = pythonData.map { pythonCustomHomeworkStatus ->
+            CustomHomeworkStatus(
                 name = pythonCustomHomeworkStatus.name
             )
-            customHomeworkStatusDao.insert(customHomeworkStatus)
         }
+        customHomeworkStatusDao.insertAll(statusesToInsert)
     }
 
     private suspend fun importCustomHomeworkTypes(uri: Uri) {
         val content = readFileContent(uri)
         val pythonData = json.decodeFromString<List<PythonCustomHomeworkType>>(content)
-        pythonData.forEach { pythonCustomHomeworkType ->
-            val customHomeworkType = CustomHomeworkType(
+        val typesToInsert = pythonData.map { pythonCustomHomeworkType ->
+            CustomHomeworkType(
                 name = pythonCustomHomeworkType.name
             )
-            customHomeworkTypeDao.insert(customHomeworkType)
         }
-
+        customHomeworkTypeDao.insertAll(typesToInsert)
     }
 }


### PR DESCRIPTION
### 🐢 The Bottleneck
The `JsonImporter` (used for legacy fragmented data ingestion) was performing individual database `insert` calls and $O(N)$ lookup queries (like `getStudentByStringId`) inside loops. For a classroom with 30 students and hundreds of historical logs, this resulted in thousands of sequential database round-trips, causing significant UI hangs and slow ingestion.

### 🐇 The Fix
1.  **Bulk Operations**: Added `insertAll` to `StudentGroupDao` and `HomeworkTemplateDao`.
2.  **Atomicity & Speed**: Wrapped the entire `importClassroomData` process in a single database transaction using `db.withTransaction`.
3.  **O(1) Resolution**:
    *   Pre-fetches all `StudentGroup` records into a map for instant name-to-ID lookup.
    *   Captures inserted student IDs from a bulk `insertAll` call and maps them to their original Python string UUIDs (JSON keys) in a single pass.
4.  **Robust Mapping**: Refactored the student ingestion to iterate over map entries directly, ensuring `stringId` parity and positional consistency when zipping local IDs.

### 📉 The Impact
- **Database I/O**: Reduced from $O(L)$ individual writes to $O(1)$ bulk transactions per data category.
- **Query Count**: Eliminated $O(N)$ student lookups and $O(S)$ group lookups during log/student ingestion.
- **Performance**: Dramatically faster import times for large legacy datasets, especially on devices with slower internal storage.

---
*PR created automatically by Jules for task [10492904470979392396](https://jules.google.com/task/10492904470979392396) started by @YMSeatt*