### PR TITLE
🌉 Bridge: Port Multi-Word Initials Logic from Python

### DIFF
--- a/app/src/main/java/com/example/myapplication/util/StringExtensions.kt
+++ b/app/src/main/java/com/example/myapplication/util/StringExtensions.kt
@@ -107,3 +107,29 @@ fun maskStudentName(name: String): String {
         }
     }
 }
+
+/**
+ * Generates short initials for a multi-word string.
+ * e.g., "Great Participation" -> "GP", "Off Task" -> "OT".
+ *
+ * This is a mobile-optimized port of the Python blueprint:
+ * ''.join(part[0].upper() for part in name.split() if part)
+ */
+fun String.generateLogInitials(): String {
+    if (this.isBlank()) return ""
+    val result = StringBuilder()
+    var isNewWord = true
+
+    for (i in this.indices) {
+        val c = this[i]
+        if (c.isWhitespace()) {
+            isNewWord = true
+        } else {
+            if (isNewWord) {
+                result.append(c.uppercaseChar())
+                isNewWord = false
+            }
+        }
+    }
+    return result.toString()
+}

--- a/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
@@ -97,6 +97,7 @@ import com.example.myapplication.labs.ghost.link.GhostLinkEngine
 import com.example.myapplication.labs.ghost.GhostOracle
 import com.example.myapplication.labs.ghost.util.GhostSeedEngine
 import com.example.myapplication.util.SecurityUtil
+import com.example.myapplication.util.generateLogInitials
 import com.example.myapplication.labs.ghost.memento.GhostMementoStore
 import com.example.myapplication.labs.ghost.memento.GhostMementoMapper
 import com.example.myapplication.labs.ghost.memento.MementoHistory
@@ -1453,7 +1454,7 @@ class SeatingChartViewModel @Inject constructor(
                                 if (behaviorDisplayTimeout > 0 && currentTime >= event.timestamp + timeoutMs) break
 
                                 val description = if (useInitialsForBehavior) {
-                                    behaviorInitialsMap[event.type] ?: event.type.first().toString()
+                                    behaviorInitialsMap[event.type] ?: event.type.generateLogInitials()
                                 } else {
                                     event.type
                                 }
@@ -1472,7 +1473,7 @@ class SeatingChartViewModel @Inject constructor(
 
                                 val status = log.status
                                 val statusDescription = if (useInitialsForHomework) {
-                                    homeworkInitialsMap[status] ?: if (status.isNotEmpty()) status.first().toString() else "?"
+                                    homeworkInitialsMap[status] ?: status.generateLogInitials().ifEmpty { "?" }
                                 } else {
                                     status
                                 }
@@ -1491,7 +1492,7 @@ class SeatingChartViewModel @Inject constructor(
                                 if (quizDisplayTimeout > 0 && currentTime >= log.loggedAt + timeoutMs) break
 
                                 quizDescription.add(if (useInitialsForQuiz) {
-                                    quizInitialsMap[log.quizName] ?: log.quizName.first().toString()
+                                    quizInitialsMap[log.quizName] ?: log.quizName.generateLogInitials()
                                 } else {
                                     log.quizName
                                 })
@@ -1514,7 +1515,7 @@ class SeatingChartViewModel @Inject constructor(
                                     val log = hLogsSess[i]
                                     val status = log.status
                                     val statusDescription = if (useInitialsForHomework) {
-                                        homeworkInitialsMap[status] ?: if (status.isNotEmpty()) status.first().toString() else "?"
+                                        homeworkInitialsMap[status] ?: status.generateLogInitials().ifEmpty { "?" }
                                     } else {
                                         status
                                     }

--- a/app/src/test/java/com/example/myapplication/util/StringExtensionsTest.kt
+++ b/app/src/test/java/com/example/myapplication/util/StringExtensionsTest.kt
@@ -46,4 +46,17 @@ class StringExtensionsTest {
         assertEquals("X", maskStudentName("X")) // Single char name
         assertEquals("", maskStudentName("   "))
     }
+
+    @Test
+    fun testGenerateLogInitials() {
+        assertEquals("GP", "Great Participation".generateLogInitials())
+        assertEquals("OT", "Off Task".generateLogInitials())
+        assertEquals("T", "Talking".generateLogInitials())
+        assertEquals("MP", "Math Problems".generateLogInitials())
+        assertEquals("MWH", "Multiple Words Here".generateLogInitials())
+        assertEquals("S", "S".generateLogInitials())
+        assertEquals("", "".generateLogInitials())
+        assertEquals("", "   ".generateLogInitials())
+        assertEquals("ABC", "  a b c  ".generateLogInitials())
+    }
 }


### PR DESCRIPTION
### 🌉 Bridge: Port Multi-Word Initials Logic from Python

This PR implements logical parity between the Python desktop application and the Android app for log entry initial generation.

#### 🐍 Source
Reference: `Python/seatingchartmain.py` lines 619-623:
```python
if name in initial_overrides and initial_overrides[name]: temp_initials.append(initial_overrides[name])
elif name: temp_initials.append(''.join(part[0].upper() for part in name.split() if part))
else: temp_initials.append("?")
```

#### 🤖 Implementation
Modified `app/src/main/java/com/example/myapplication/util/StringExtensions.kt` to include `generateLogInitials()`, a BOLT-optimized single-pass Kotlin equivalent.
Integrated the utility into `app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt` across four display pipeline locations (Behaviors, Homework Status, Quizzes, and Live Sessions).

#### 🔄 Mapping Strategy
The Python list comprehension `''.join(part[0].upper() for part in name.split() if part)` was translated into a high-performance iterative `StringBuilder` loop in Kotlin to minimize object allocations during the reactive seating chart redraws.

#### 🧪 Verification
- Added unit tests in `StringExtensionsTest.kt` covering "GP", "OT", "T", "MP", "MWH", and whitespace edge cases.
- Verified logic via Python simulation script due to environment build constraints.
- Manual code review confirms exact parity with Python blueprint behavior.

---
*PR created automatically by Jules for task [2105425610819305524](https://jules.google.com/task/2105425610819305524) started by @YMSeatt*