### PR TITLE
📜 Scribe: Documentation update for ConditionalFormattingRuleViewModel

### DIFF
--- a/app/src/main/java/com/example/myapplication/viewmodel/ConditionalFormattingRuleViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/ConditionalFormattingRuleViewModel.kt
@@ -13,6 +13,18 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+/**
+ * ViewModel responsible for managing the configuration and lifecycle of Conditional Formatting rules.
+ *
+ * This ViewModel serves as the state manager for the rule builder UI. It aggregates multiple
+ * data streams—including user-defined behaviors, system-level behaviors, and student groups—to
+ * provide the "available options" for the reactive styling DSL.
+ *
+ * ### Architectural Role:
+ * It bridges the rule editing UI with the persistence layer ([ConditionalFormattingRuleDao]),
+ * allowing teachers to define complex visual logic (e.g., highlighting students with 3+ negative
+ * logs) that drives the "Fluid Interaction" seating chart experience.
+ */
 @HiltViewModel
 class ConditionalFormattingRuleViewModel @Inject constructor(
     private val conditionalFormattingRuleDao: ConditionalFormattingRuleDao,
@@ -20,31 +32,65 @@ class ConditionalFormattingRuleViewModel @Inject constructor(
     private val systemBehaviorDao: SystemBehaviorDao,
     private val studentGroupDao: StudentGroupDao
 ) : ViewModel() {
+
+    /** Reactive stream of all defined conditional formatting rules. */
     val rules: LiveData<List<ConditionalFormattingRule>> = conditionalFormattingRuleDao.getAllRules()
+
+    /**
+     * Stream of teacher-defined behavior categories. Used as triggers in the `behavior_count`
+     * condition type.
+     */
     val customBehaviors: LiveData<List<com.example.myapplication.data.CustomBehavior>> = customBehaviorDao.getAllCustomBehaviors()
+
+    /**
+     * Stream of standardized, system-level feedback categories. Provides consistent triggers
+     * for rules across all classrooms.
+     */
     val systemBehaviors: LiveData<List<com.example.myapplication.data.SystemBehavior>> =
         systemBehaviorDao.getAllSystemBehaviors().asLiveData()
+
+    /**
+     * Stream of all student groups. Used to populate the "Group" condition type, allowing
+     * for group-based visual feedback.
+     */
     val studentGroups: LiveData<List<com.example.myapplication.data.StudentGroup>> = studentGroupDao.getAllStudentGroups().asLiveData()
 
 
+    /**
+     * Persists a new conditional formatting rule to the database.
+     * @param rule The rule entity containing the JSON-based condition and format.
+     */
     fun addRule(rule: ConditionalFormattingRule) {
         viewModelScope.launch {
             conditionalFormattingRuleDao.insertRule(rule)
         }
     }
 
+    /**
+     * Updates an existing rule's configuration or priority.
+     * @param rule The updated rule entity.
+     */
     fun updateRule(rule: ConditionalFormattingRule) {
         viewModelScope.launch {
             conditionalFormattingRuleDao.updateRule(rule)
         }
     }
 
+    /**
+     * Performs a bulk update for multiple rules. Typically used when reordering rules
+     * to adjust their execution priority.
+     * @param rules The list of rules with updated properties (e.g., priority).
+     */
     fun bulkUpdateRules(rules: List<ConditionalFormattingRule>) {
         viewModelScope.launch {
             conditionalFormattingRuleDao.updateRules(rules)
         }
     }
 
+    /**
+     * Removes a rule from the database, permanently disabling its visual effect.
+     * @param rule The rule to delete.
+     */
     fun deleteRule(rule: ConditionalFormattingRule) {
         viewModelScope.launch {
             conditionalFormattingRuleDao.deleteRule(rule)


### PR DESCRIPTION
🔦 *The Blind Spot:* The `ConditionalFormattingRuleViewModel` was a critical but entirely undocumented component in the application's reactive styling architecture. While it coordinates the configuration of the seating chart's dynamic visual feedback, its role and the purpose of its various data streams were not formally explained.

💡 *The Insight:* I implemented comprehensive KDocs that clarify its position as a bridge between the rule editing UI and the persistence layer. The new documentation explains how it aggregates diverse data sources (custom behaviors, system behaviors, and student groups) to populate the "Available Options" in the rule builder DSL.

📖 *Preview:*
```kotlin
/**
 * ViewModel responsible for managing the configuration and lifecycle of Conditional Formatting rules.
 * ...
 * It bridges the rule editing UI with the persistence layer ([ConditionalFormattingRuleDao]),
 * allowing teachers to define complex visual logic...
 */
```

---
*PR created automatically by Jules for task [15736389077574226854](https://jules.google.com/task/15736389077574226854) started by @YMSeatt*