### PR TITLE
🌉 Bridge: Port Homework Mark Management from Python

### DIFF
--- a/app/src/main/java/com/example/myapplication/di/DatabaseModule.kt
+++ b/app/src/main/java/com/example/myapplication/di/DatabaseModule.kt
@@ -8,6 +8,7 @@ import com.example.myapplication.data.CustomBehaviorDao
 import com.example.myapplication.data.CustomHomeworkStatusDao
 import com.example.myapplication.data.CustomHomeworkTypeDao
 import com.example.myapplication.data.HomeworkLogDao
+import com.example.myapplication.data.HomeworkMarkMetadataDao
 import com.example.myapplication.data.QuizLogDao
 import com.example.myapplication.data.EmailScheduleDao
 import com.example.myapplication.data.FurnitureDao
@@ -179,5 +180,11 @@ object DatabaseModule {
     @Provides
     fun provideHomeworkDao(appDatabase: AppDatabase): HomeworkDao {
         return appDatabase.homeworkDao()
+    }
+
+    /** Provides the [HomeworkMarkMetadataDao] for mapping homework statuses to point values. */
+    @Provides
+    fun provideHomeworkMarkMetadataDao(appDatabase: AppDatabase): HomeworkMarkMetadataDao {
+        return appDatabase.homeworkMarkMetadataDao()
     }
 }

--- a/app/src/main/java/com/example/myapplication/ui/settings/DataSettingsTab.kt
+++ b/app/src/main/java/com/example/myapplication/ui/settings/DataSettingsTab.kt
@@ -96,6 +96,12 @@ fun DataSettingsTab(
     var quizMarkTypeNameError by remember { mutableStateOf<String?>(null) }
     var quizMarkPointsError by remember { mutableStateOf<String?>(null) }
 
+    val homeworkMarkMetadataList by settingsViewModel.homeworkMarkMetadata.observeAsState(initial = emptyList())
+    var newHomeworkMarkName by remember { mutableStateOf("") }
+    var newHomeworkMarkPoints by remember { mutableStateOf("") }
+    var homeworkMarkNameError by remember { mutableStateOf<String?>(null) }
+    var homeworkMarkPointsError by remember { mutableStateOf<String?>(null) }
+
     val importStudentsLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent(),
         onResult = { uri: Uri? ->
@@ -158,6 +164,7 @@ fun DataSettingsTab(
     var showResetHomeworkTypesConfirm by remember { mutableStateOf(false) }
     var showResetHomeworkStatusesConfirm by remember { mutableStateOf(false) }
     var showResetQuizMarkTypesConfirm by remember { mutableStateOf(false) }
+    var showResetHomeworkMarkMetadataConfirm by remember { mutableStateOf(false) }
     var showResetApplicationConfirm1 by remember { mutableStateOf(false) }
     var showResetApplicationConfirm2 by remember { mutableStateOf(false) }
 
@@ -176,6 +183,27 @@ fun DataSettingsTab(
             },
             dismissButton = {
                 TextButton(onClick = { showResetApplicationConfirm1 = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
+    if (showResetHomeworkMarkMetadataConfirm) {
+        AlertDialog(
+            onDismissRequest = { showResetHomeworkMarkMetadataConfirm = false },
+            title = { Text("Reset Homework Mark Types") },
+            text = { Text("Are you sure you want to reset all homework mark types to application defaults? This will delete all custom mark types.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    settingsViewModel.resetHomeworkMarkMetadataToDefaults()
+                    showResetHomeworkMarkMetadataConfirm = false
+                }) {
+                    Text("Reset")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showResetHomeworkMarkMetadataConfirm = false }) {
                     Text("Cancel")
                 }
             }
@@ -610,6 +638,84 @@ fun DataSettingsTab(
                 enabled = newQuizMarkTypeName.isNotBlank() && newQuizMarkDefaultPoints.toDoubleOrNull() != null
             ) {
                 Text("Add Quiz Mark Type")
+            }
+            HorizontalDivider(Modifier.padding(top = 8.dp))
+        }
+
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("Manage Homework Mark Types", style = MaterialTheme.typography.titleMedium)
+                TextButton(onClick = { showResetHomeworkMarkMetadataConfirm = true }) {
+                    Text("Reset to Defaults")
+                }
+            }
+        }
+        items(homeworkMarkMetadataList) { metadata ->
+            Card(modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 4.dp)) {
+                Column(modifier = Modifier.padding(8.dp)) {
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+                        Text(metadata.name, style = MaterialTheme.typography.bodyLarge)
+                        IconButton(onClick = {
+                            settingsViewModel.deleteHomeworkMarkMetadata(metadata)
+                        }) {
+                            Icon(Icons.Filled.Delete, contentDescription = "Remove homework mark type")
+                        }
+                    }
+                    Text("Points: ${metadata.defaultPoints}")
+                }
+            }
+        }
+
+        item {
+            Spacer(Modifier.height(8.dp))
+            Text("Add New Homework Mark Type:", style = MaterialTheme.typography.titleSmall)
+            OutlinedTextField(
+                value = newHomeworkMarkName,
+                onValueChange = { newHomeworkMarkName = it; homeworkMarkNameError = null },
+                label = { Text("Mark type name") },
+                modifier = Modifier.fillMaxWidth(),
+                isError = homeworkMarkNameError != null
+            )
+            homeworkMarkNameError?.let {
+                Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+            }
+
+            OutlinedTextField(
+                value = newHomeworkMarkPoints,
+                onValueChange = { newHomeworkMarkPoints = it; homeworkMarkPointsError = null },
+                label = { Text("Default points") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth(),
+                isError = homeworkMarkPointsError != null
+            )
+            homeworkMarkPointsError?.let {
+                Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+            }
+
+            Button(
+                onClick = {
+                    val isNameValid = newHomeworkMarkName.isNotBlank()
+                    val pointsValue = newHomeworkMarkPoints.toDoubleOrNull()
+
+                    homeworkMarkNameError = if (isNameValid) null else "Name cannot be blank."
+                    homeworkMarkPointsError = if (pointsValue != null) null else "Points must be a valid number."
+
+                    if (isNameValid && pointsValue != null) {
+                        settingsViewModel.addHomeworkMarkMetadata(newHomeworkMarkName.trim(), pointsValue)
+                        newHomeworkMarkName = ""
+                        newHomeworkMarkPoints = ""
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = newHomeworkMarkName.isNotBlank() && newHomeworkMarkPoints.toDoubleOrNull() != null
+            ) {
+                Text("Add Homework Mark Type")
             }
             HorizontalDivider(Modifier.padding(top = 8.dp))
         }

--- a/app/src/main/java/com/example/myapplication/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/SettingsViewModel.kt
@@ -20,6 +20,8 @@ import com.example.myapplication.data.CustomHomeworkType
 import com.example.myapplication.data.CustomHomeworkTypeDao
 import com.example.myapplication.data.FurnitureDao
 import com.example.myapplication.data.HomeworkLogDao
+import com.example.myapplication.data.HomeworkMarkMetadata
+import com.example.myapplication.data.HomeworkMarkMetadataDao
 import com.example.myapplication.data.HomeworkTemplateDao
 import com.example.myapplication.data.LayoutTemplateDao
 import com.example.myapplication.data.QuizMarkType
@@ -83,6 +85,7 @@ class SettingsViewModel @Inject constructor(
     private val customHomeworkTypeDao: CustomHomeworkTypeDao,
     private val customHomeworkStatusDao: CustomHomeworkStatusDao,
     private val quizMarkTypeDao: QuizMarkTypeDao,
+    private val homeworkMarkMetadataDao: HomeworkMarkMetadataDao,
     private val quizTemplateDao: QuizTemplateDao,
     private val homeworkTemplateDao: HomeworkTemplateDao,
     private val systemBehaviorDao: com.example.myapplication.data.SystemBehaviorDao,
@@ -414,6 +417,16 @@ class SettingsViewModel @Inject constructor(
         quizMarkTypeDao.replaceAll(defaults)
     }
 
+    fun resetHomeworkMarkMetadataToDefaults() = viewModelScope.launch {
+        val defaults = listOf(
+            HomeworkMarkMetadata(name = "Complete", defaultPoints = 10.0),
+            HomeworkMarkMetadata(name = "Incomplete", defaultPoints = 5.0),
+            HomeworkMarkMetadata(name = "Not Done", defaultPoints = 0.0),
+            HomeworkMarkMetadata(name = "Effort Score (1-5)", defaultPoints = 3.0)
+        )
+        homeworkMarkMetadataDao.replaceAll(defaults)
+    }
+
     fun resetLiveHomeworkSelectOptionsToDefaults() {
         updateLiveHomeworkSelectOptions("Done,Not Done,Signed,Returned")
     }
@@ -430,6 +443,20 @@ class SettingsViewModel @Inject constructor(
     }
     fun deleteQuizMarkType(quizMarkType: QuizMarkType) = viewModelScope.launch {
         quizMarkTypeDao.delete(quizMarkType)
+    }
+
+    val homeworkMarkMetadata: LiveData<List<HomeworkMarkMetadata>> = homeworkMarkMetadataDao.getAllHomeworkMarkMetadata().asLiveData()
+
+    fun addHomeworkMarkMetadata(name: String, points: Double) = viewModelScope.launch {
+        homeworkMarkMetadataDao.insert(HomeworkMarkMetadata(name = name, defaultPoints = points))
+    }
+
+    fun updateHomeworkMarkMetadata(metadata: HomeworkMarkMetadata) = viewModelScope.launch {
+        homeworkMarkMetadataDao.update(metadata)
+    }
+
+    fun deleteHomeworkMarkMetadata(metadata: HomeworkMarkMetadata) = viewModelScope.launch {
+        homeworkMarkMetadataDao.delete(metadata)
     }
 
 

--- a/app/src/test/java/com/example/myapplication/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/example/myapplication/viewmodel/SettingsViewModelTest.kt
@@ -62,6 +62,8 @@ class SettingsViewModelTest {
     @MockK(relaxed = true)
     lateinit var quizMarkTypeDao: QuizMarkTypeDao
     @MockK(relaxed = true)
+    lateinit var homeworkMarkMetadataDao: HomeworkMarkMetadataDao
+    @MockK(relaxed = true)
     lateinit var quizTemplateDao: QuizTemplateDao
     @MockK(relaxed = true)
     lateinit var homeworkTemplateDao: HomeworkTemplateDao
@@ -71,6 +73,8 @@ class SettingsViewModelTest {
     lateinit var behaviorEventDao: BehaviorEventDao
     @MockK(relaxed = true)
     lateinit var homeworkLogDao: HomeworkLogDao
+    @MockK(relaxed = true)
+    lateinit var securityUtil: SecurityUtil
 
     private lateinit var viewModel: SettingsViewModel
 
@@ -167,11 +171,13 @@ class SettingsViewModelTest {
             customHomeworkTypeDao,
             customHomeworkStatusDao,
             quizMarkTypeDao,
+            homeworkMarkMetadataDao,
             quizTemplateDao,
             homeworkTemplateDao,
             systemBehaviorDao,
             behaviorEventDao,
-            homeworkLogDao
+            homeworkLogDao,
+            securityUtil
         )
     }
 
@@ -262,5 +268,15 @@ class SettingsViewModelTest {
 
         // Then
         coVerify { customHomeworkStatusDao.replaceAll(any()) }
+    }
+
+    @Test
+    fun `resetHomeworkMarkMetadataToDefaults should call replaceAll on DAO`() = runTest {
+        // When
+        viewModel.resetHomeworkMarkMetadataToDefaults()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        coVerify { homeworkMarkMetadataDao.replaceAll(any()) }
     }
 }


### PR DESCRIPTION
This change ports the "Homework Mark Management" feature from the Python blueprint (`quizhomework.py`) to the Android application.

### Changes:
- **`SettingsViewModel.kt`**: Added methods to add, update, delete, and reset `HomeworkMarkMetadata`.
- **`DataSettingsTab.kt`**: Implemented the UI for managing homework mark types, including a list, addition form, and reset confirmation dialog.
- **`DatabaseModule.kt`**: Added Hilt provider for `HomeworkMarkMetadataDao`.
- **`SettingsViewModelTest.kt`**: Updated tests to support the new DAO dependency and added a test case for resetting metadata.

### Logic Parity:
Ensured the default homework marks match the Python prototype:
- Complete: 10.0
- Incomplete: 5.0
- Not Done: 0.0
- Effort Score (1-5): 3.0

Verified via manual code logic review and consistency checks with existing Quiz Mark Type functionality.

---
*PR created automatically by Jules for task [17458104333866578140](https://jules.google.com/task/17458104333866578140) started by @YMSeatt*