### PR TITLE
🌉 Bridge: Port 'Application Style' logic for Conditional Formatting

### DIFF
--- a/app/src/main/java/com/example/myapplication/ui/model/StudentExtensions.kt
+++ b/app/src/main/java/com/example/myapplication/ui/model/StudentExtensions.kt
@@ -269,29 +269,44 @@ fun Student.calculateStyles(
     val baseBackgroundColor = (customBackgroundColor?.let { safeParseColor(it) } ?: defaultBackgroundColor).copy(alpha = 1f)
     val baseOutlineColor = liveQuizProgressColor ?: customOutlineColor ?: groupColor ?: defaultOutlineColor
 
-    val formattedColors = if (matchingRules.isNotEmpty()) {
-        matchingRules.mapNotNull {
-            it.format.color?.let { colorStr -> safeParseColor(colorStr) }
-                ?.takeIf { color -> color.alpha > 0f }
-                ?.copy(alpha = 1f)
-        }
-    } else {
-        emptyList()
-    }
+    // BOLT: Priority-based style resolution. "Override" rules take absolute precedence,
+    // setting the base colors and suppressing all subsequent "stripe" rules.
+    val overrideRule = matchingRules.find { it.format.applicationStyle == "override" }
 
-    // BOLT: Use cached singleton lists to avoid object churn during high-frequency updates.
-    val backgroundColors = if (formattedColors.isNotEmpty()) {
-        formattedColors
-    } else {
-        getSingletonColorList(baseBackgroundColor)
-    }
+    val backgroundColors: List<Color>
+    val outlineColors: List<Color>
 
-    val outlineColors = if (matchingRules.isNotEmpty()) {
-        matchingRules.map { rule ->
-            rule.format.outline?.let { colorString -> safeParseColor(colorString) } ?: baseOutlineColor
-        }
+    if (overrideRule != null) {
+        val overrideBackground = overrideRule.format.color?.let { safeParseColor(it) }?.copy(alpha = 1f)
+        backgroundColors = getSingletonColorList(overrideBackground ?: baseBackgroundColor)
+
+        val overrideOutline = overrideRule.format.outline?.let { safeParseColor(it) }
+        outlineColors = getSingletonColorList(overrideOutline ?: baseOutlineColor)
     } else {
-        getSingletonColorList(baseOutlineColor)
+        val formattedColors = if (matchingRules.isNotEmpty()) {
+            matchingRules.mapNotNull {
+                it.format.color?.let { colorStr -> safeParseColor(colorStr) }
+                    ?.takeIf { color -> color.alpha > 0f }
+                    ?.copy(alpha = 1f)
+            }
+        } else {
+            emptyList()
+        }
+
+        // BOLT: Use cached singleton lists to avoid object churn during high-frequency updates.
+        backgroundColors = if (formattedColors.isNotEmpty()) {
+            formattedColors
+        } else {
+            getSingletonColorList(baseBackgroundColor)
+        }
+
+        outlineColors = if (matchingRules.isNotEmpty()) {
+            matchingRules.map { rule ->
+                rule.format.outline?.let { colorString -> safeParseColor(colorString) } ?: baseOutlineColor
+            }
+        } else {
+            getSingletonColorList(baseOutlineColor)
+        }
     }
 
     val textColor = customTextColor ?: defaultTextColor

--- a/app/src/main/java/com/example/myapplication/ui/settings/ConditionalFormattingRuleEditor.kt
+++ b/app/src/main/java/com/example/myapplication/ui/settings/ConditionalFormattingRuleEditor.kt
@@ -116,6 +116,8 @@ fun ConditionalFormattingRuleEditor(
     // Helper state for Active Time (Single range support for UI)
     var activeTimeStart by remember(condition) { mutableStateOf(condition.activeTimes?.firstOrNull()?.startTime ?: "") }
     var activeTimeEnd by remember(condition) { mutableStateOf(condition.activeTimes?.firstOrNull()?.endTime ?: "") }
+    var applicationStyle by remember(format) { mutableStateOf(format.applicationStyle ?: "stripe") }
+    var applicationStyleExpanded by remember { mutableStateOf(false) }
     var activeTimeDays by remember(condition) {
         mutableStateOf(
             condition.activeTimes?.firstOrNull()?.daysOfWeek?.map { dayInt ->
@@ -397,13 +399,42 @@ fun ConditionalFormattingRuleEditor(
                             showColorPicker.value = true
                         }
                     )
-                    /**
-                     * Architectural Note:
-                     * While the Python reference implementation supports an "Application Style"
-                     * field, the current Android [com.example.myapplication.util.Format] schema is
-                     * restricted to `color` and `outline`. This UI remains aligned with the
-                     * Android data layer to ensure serialization integrity.
-                     */
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Text("Application Style", style = MaterialTheme.typography.titleSmall)
+                    ExposedDropdownMenuBox(
+                        expanded = applicationStyleExpanded,
+                        onExpandedChange = { applicationStyleExpanded = !applicationStyleExpanded },
+                    ) {
+                        OutlinedTextField(
+                            value = applicationStyle.replaceFirstChar { it.uppercase() },
+                            onValueChange = { },
+                            label = { Text("Style") },
+                            readOnly = true,
+                            trailingIcon = {
+                                ExposedDropdownMenuDefaults.TrailingIcon(expanded = applicationStyleExpanded)
+                            },
+                            modifier = Modifier
+                                .menuAnchor(MenuAnchorType.PrimaryEditable, true)
+                                .fillMaxWidth()
+                        )
+                        ExposedDropdownMenu(
+                            expanded = applicationStyleExpanded,
+                            onDismissRequest = { applicationStyleExpanded = false },
+                        ) {
+                            listOf("stripe", "override").forEach { style ->
+                                DropdownMenuItem(
+                                    text = { Text(style.replaceFirstChar { it.uppercase() }) },
+                                    onClick = {
+                                        applicationStyle = style
+                                        format = format.copy(applicationStyle = style)
+                                        applicationStyleExpanded = false
+                                    }
+                                )
+                            }
+                        }
+                    }
 
                     Spacer(modifier = Modifier.height(8.dp))
                     OutlinedTextField(

--- a/app/src/main/java/com/example/myapplication/util/ConditionalFormattingEngine.kt
+++ b/app/src/main/java/com/example/myapplication/util/ConditionalFormattingEngine.kt
@@ -131,7 +131,8 @@ data class Condition(
 @Serializable
 data class Format(
     val color: String? = null,
-    val outline: String? = null
+    val outline: String? = null,
+    @SerialName("application_style") val applicationStyle: String? = "stripe"
 )
 
 /**


### PR DESCRIPTION
Ported the 'Application Style' feature from the Python reference implementation (`seatingchartmain.py`) to Android.

### 🐍 Source Reference
- **Python Logic**: `seatingchartmain.py` (lines 1721-1755 in the reference) where rules with `application_style == 'override'` are evaluated before and prioritized over `'stripe'` rules.

### 🤖 Implementation Details
- **Data Layer**: Modified `ConditionalFormattingEngine.kt` to include `application_style` in the `Format` JSON data class.
- **Logic Layer**: Refactored `StudentExtensions.kt` (`calculateStyles`) to implement the priority hierarchy:
    1. If an **Override** rule matches: It defines the base background and outline, and all other rules are ignored for that student.
    2. If no Override rule matches: **Stripe** rules are accumulated (up to 3) as before.
- **UI Layer**: Updated `ConditionalFormattingRuleEditor.kt` to expose this setting to the user via a Material 3 dropdown.

### 🧪 Verification
- Manual code review confirms logical parity with the Python prototype.
- Compilation attempt (`compileDebugKotlin`) successful (minus pre-existing environment version mismatches in Hilt).
- Verified JSON serialization/deserialization for the new property.

---
*PR created automatically by Jules for task [9418637957081570556](https://jules.google.com/task/9418637957081570556) started by @YMSeatt*