### PR TITLE
🛡️ Shield: [Security Hardening] in Ghost Lab Neural Dossier

### DIFF
--- a/app/src/main/java/com/example/myapplication/labs/ghost/morph/GhostDossierScreen.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/morph/GhostDossierScreen.kt
@@ -2,6 +2,7 @@ package com.example.myapplication.labs.ghost.morph
 
 import android.graphics.RuntimeShader
 import android.os.Build
+import android.view.WindowManager
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -25,6 +26,7 @@ import com.example.myapplication.labs.ghost.GhostLinkEngine
 import com.example.myapplication.labs.ghost.util.GhostSeedEngine
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import com.example.myapplication.util.findActivity
 
 /**
  * GhostDossierScreen: A high-fidelity, full-screen student dossier.
@@ -44,6 +46,16 @@ fun GhostDossierScreen(
 ) {
     val dossierMarkdown = remember(studentId, studentName) {
         GhostLinkEngine.generateNeuralDossier(studentId, studentName)
+    }
+
+    val context = LocalContext.current
+
+    DisposableEffect(Unit) {
+        val activity = context.findActivity()
+        activity?.window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        onDispose {
+            activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
     }
 
     val infiniteTransition = rememberInfiniteTransition(label = "dossier_pulse")


### PR DESCRIPTION
### 🛡️ Shield: Security Hardening in Ghost Lab Neural Dossier

#### 🔓 The Vulnerability
The **Ghost Neural Dossier** (a high-fidelity student analysis report) was vulnerable to unauthorized screen capture (screenshots and screen recordings) when accessed via "Neural Seed" home screen shortcuts. While the primary seating chart correctly enforced privacy protections, the deep-link navigation path into the dossier via `MainActivity` lacked the `FLAG_SECURE` safeguard, potentially exposing student PII and predictive analytics to the system or malicious background apps.

#### 🔐 The Fix
Implemented a `DisposableEffect` within the `GhostDossierScreen` composable to proactively manage the `WindowManager.LayoutParams.FLAG_SECURE` state. 
- **Activation**: Automatically applies `FLAG_SECURE` to the host window when the dossier is composed.
- **Cleanup**: Reliably clears the flag when the screen is disposed (e.g., when the user "De-Phases" or navigates back), ensuring other parts of the application remain accessible for standard system interactions.
- **Robustness**: Utilizes the `Context.findActivity()` utility to safely resolve the host activity across different navigation contexts (Direct host vs. `GhostMorphActivity`).

#### 📜 Compliance
This hardening measure aligns with:
- **OWASP MASVS-STORAGE-1**: Ensuring sensitive data is not leaked to external components (like the system screenshot gallery or task switcher).
- **Google Play Data Safety Standards**: Proactively protecting Personal Identifiable Information (PII) from unauthorized capture.
- **Application Privacy Policy**: Enforces the "Privacy Shield" philosophy across all experimental R&D modules.

---
*PR created automatically by Jules for task [17972992381293009530](https://jules.google.com/task/17972992381293009530) started by @YMSeatt*