### PR TITLE
Port High-Integrity Student Deletion from Python

### DIFF
--- a/app/src/main/java/com/example/myapplication/commands/DeleteStudentCommand.kt
+++ b/app/src/main/java/com/example/myapplication/commands/DeleteStudentCommand.kt
@@ -1,25 +1,50 @@
 package com.example.myapplication.commands
 
+import com.example.myapplication.data.BehaviorEvent
+import com.example.myapplication.data.HomeworkLog
+import com.example.myapplication.data.QuizLog
 import com.example.myapplication.data.Student
 import com.example.myapplication.viewmodel.SeatingChartViewModel
 
 /**
  * Command to remove a student from the seating chart.
- * Reversing this command re-inserts the student back into the database.
+ *
+ * This is a "High-Integrity" command ported from the Python blueprint. When a student is deleted,
+ * it captures a complete snapshot of all associated behavioral, quiz, and homework logs.
+ * This ensures that undoing a deletion restores the student's entire history,
+ * maintaining data continuity despite database cascade deletions.
  *
  * @param viewModel The ViewModel to perform the database operations.
  * @param student The [Student] entity to be deleted.
+ * @param behaviorLogs Historical behavior events for this student.
+ * @param quizLogs Historical quiz performance logs for this student.
+ * @param homeworkLogs Historical homework completion logs for this student.
  */
 class DeleteStudentCommand(
     internal val viewModel: SeatingChartViewModel,
-    internal val student: Student
+    internal val student: Student,
+    private val behaviorLogs: List<BehaviorEvent> = emptyList(),
+    private val quizLogs: List<QuizLog> = emptyList(),
+    private val homeworkLogs: List<HomeworkLog> = emptyList()
 ) : Command {
     override suspend fun execute() {
         viewModel.internalDeleteStudent(student)
     }
 
     override suspend fun undo() {
+        // Step 1: Restore the student record first to satisfy foreign key constraints.
         viewModel.internalAddStudent(student)
+
+        // Step 2: Restore all historical logs in bulk.
+        if (behaviorLogs.isNotEmpty()) {
+            viewModel.internalAddBehaviorEvents(behaviorLogs)
+        }
+        if (quizLogs.isNotEmpty()) {
+            viewModel.internalAddQuizLogs(quizLogs)
+        }
+        if (homeworkLogs.isNotEmpty()) {
+            viewModel.internalAddHomeworkLogs(homeworkLogs)
+        }
     }
 
     override fun getDescription(): String = "Delete student: ${student.firstName} ${student.lastName}"

--- a/app/src/main/java/com/example/myapplication/data/BehaviorEventDao.kt
+++ b/app/src/main/java/com/example/myapplication/data/BehaviorEventDao.kt
@@ -57,6 +57,9 @@ interface BehaviorEventDao {
     @Query("SELECT * FROM behavior_events WHERE studentId = :studentId ORDER BY timestamp DESC LIMIT :limit")
     suspend fun getRecentBehaviorEventsForStudentList(studentId: Long, limit: Int): List<BehaviorEvent>
 
+    @Query("SELECT * FROM behavior_events WHERE studentId = :studentId")
+    suspend fun getBehaviorEventsForStudentNonLiveData(studentId: Long): List<BehaviorEvent>
+
     /**
      * Retrieves recent behavior events for UI display on student icons, applying
      * multiple visibility filters:

--- a/app/src/main/java/com/example/myapplication/data/HomeworkLogDao.kt
+++ b/app/src/main/java/com/example/myapplication/data/HomeworkLogDao.kt
@@ -52,6 +52,9 @@ interface HomeworkLogDao {
     @Query("SELECT * FROM homework_logs WHERE studentId = :studentId ORDER BY loggedAt DESC LIMIT :limit")
     suspend fun getRecentHomeworkLogsForStudentList(studentId: Long, limit: Int): List<HomeworkLog>
 
+    @Query("SELECT * FROM homework_logs WHERE studentId = :studentId")
+    suspend fun getHomeworkLogsForStudentNonLiveData(studentId: Long): List<HomeworkLog>
+
     /**
      * Retrieves recent homework logs for UI display on student icons, applying
      * visibility filters:

--- a/app/src/main/java/com/example/myapplication/data/QuizLogDao.kt
+++ b/app/src/main/java/com/example/myapplication/data/QuizLogDao.kt
@@ -57,6 +57,9 @@ interface QuizLogDao {
     @Query("SELECT * FROM quiz_logs WHERE studentId = :studentId ORDER BY loggedAt DESC LIMIT :limit")
     suspend fun getRecentQuizLogsForStudentList(studentId: Long, limit: Int): List<QuizLog>
 
+    @Query("SELECT * FROM quiz_logs WHERE studentId = :studentId")
+    suspend fun getQuizLogsForStudentNonLiveData(studentId: Long): List<QuizLog>
+
     /**
      * Retrieves quiz logs for UI display on student icons, specifically filtering for
      * active or recent relevant data.

--- a/app/src/main/java/com/example/myapplication/data/StudentRepository.kt
+++ b/app/src/main/java/com/example/myapplication/data/StudentRepository.kt
@@ -252,6 +252,10 @@ class StudentRepository(
         return behaviorEventDao.insert(encryptBehaviorEvent(event))
     }
 
+    suspend fun insertBehaviorEvents(events: List<BehaviorEvent>): List<Long> {
+        return behaviorEventDao.insertAll(events.map { encryptBehaviorEvent(it) })
+    }
+
     /**
      * BOLT: Centralized filtered fetch logic to handle the distinction between
      * null studentIds (all students) and empty studentIds (no students).
@@ -279,6 +283,10 @@ class StudentRepository(
      * @param studentIds Optional filter for specific students. If null, returns events for all students.
      * @return Sorted list of matching behavior events.
      */
+    suspend fun getBehaviorEventsForStudentList(studentId: Long): List<BehaviorEvent> {
+        return behaviorEventDao.getBehaviorEventsForStudentNonLiveData(studentId).map { decryptBehaviorEvent(it) }
+    }
+
     suspend fun getFilteredBehaviorEvents(startDate: Long, endDate: Long, studentIds: List<Long>? = null): List<BehaviorEvent> {
         val events = when {
             studentIds == null -> behaviorEventDao.getFilteredBehaviorEvents(startDate, endDate)
@@ -296,6 +304,14 @@ class StudentRepository(
      * @param studentIds Optional filter for specific students.
      * @return List of matching homework logs.
      */
+    suspend fun getHomeworkLogsForStudentList(studentId: Long): List<HomeworkLog> {
+        return homeworkLogDao.getHomeworkLogsForStudentNonLiveData(studentId).map { decryptHomeworkLog(it) }
+    }
+
+    suspend fun insertHomeworkLogs(logs: List<HomeworkLog>): List<Long> {
+        return homeworkLogDao.insertAll(logs.map { encryptHomeworkLog(it) })
+    }
+
     suspend fun getFilteredHomeworkLogs(startDate: Long, endDate: Long, studentIds: List<Long>? = null): List<HomeworkLog> {
         val logs = when {
             studentIds == null -> homeworkLogDao.getFilteredHomeworkLogs(startDate, endDate)
@@ -313,6 +329,14 @@ class StudentRepository(
      * @param studentIds Optional filter for specific students.
      * @return List of matching quiz logs.
      */
+    suspend fun getQuizLogsForStudentList(studentId: Long): List<QuizLog> {
+        return quizLogDao.getQuizLogsForStudentNonLiveData(studentId).map { decryptQuizLog(it) }
+    }
+
+    suspend fun insertQuizLogs(logs: List<QuizLog>): List<Long> {
+        return quizLogDao.insertAll(logs.map { encryptQuizLog(it) })
+    }
+
     suspend fun getFilteredQuizLogs(startDate: Long, endDate: Long, studentIds: List<Long>? = null): List<QuizLog> {
         val logs = when {
             studentIds == null -> quizLogDao.getFilteredQuizLogs(startDate, endDate)

--- a/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
@@ -2183,10 +2183,21 @@ class SeatingChartViewModel @Inject constructor(
 
     /**
      * Triggers the deletion of a student via the Command pattern.
+     * Captures student history to support high-integrity undo.
      */
     fun deleteStudent(student: Student) {
         viewModelScope.launch {
-            val command = DeleteStudentCommand(this@SeatingChartViewModel, student)
+            val behaviorLogs = repository.getBehaviorEventsForStudentList(student.id)
+            val quizLogs = repository.getQuizLogsForStudentList(student.id)
+            val homeworkLogs = repository.getHomeworkLogsForStudentList(student.id)
+
+            val command = DeleteStudentCommand(
+                viewModel = this@SeatingChartViewModel,
+                student = student,
+                behaviorLogs = behaviorLogs,
+                quizLogs = quizLogs,
+                homeworkLogs = homeworkLogs
+            )
             executeCommand(command)
         }
     }
@@ -2215,7 +2226,17 @@ class SeatingChartViewModel @Inject constructor(
             // BOLT: Single-pass iteration over students with O(1) set lookups
             allStudents.value?.forEach { student ->
                 if (itemIds.contains(ChartItemId(student.id.toInt(), ItemType.STUDENT))) {
-                    commands.add(DeleteStudentCommand(this@SeatingChartViewModel, student))
+                    val behaviorLogs = repository.getBehaviorEventsForStudentList(student.id)
+                    val quizLogs = repository.getQuizLogsForStudentList(student.id)
+                    val homeworkLogs = repository.getHomeworkLogsForStudentList(student.id)
+
+                    commands.add(DeleteStudentCommand(
+                        viewModel = this@SeatingChartViewModel,
+                        student = student,
+                        behaviorLogs = behaviorLogs,
+                        quizLogs = quizLogs,
+                        homeworkLogs = homeworkLogs
+                    ))
                 }
             }
 
@@ -2927,6 +2948,12 @@ class SeatingChartViewModel @Inject constructor(
         }
     }
 
+    suspend fun internalAddBehaviorEvents(events: List<BehaviorEvent>) {
+        withContext(Dispatchers.IO) {
+            repository.insertBehaviorEvents(events)
+        }
+    }
+
     fun deleteBehaviorEvent(event: BehaviorEvent) = viewModelScope.launch(Dispatchers.IO) {
         behaviorEventDao.delete(event)
         withContext(Dispatchers.Main) {
@@ -2957,6 +2984,12 @@ class SeatingChartViewModel @Inject constructor(
         }
     }
 
+    suspend fun internalAddQuizLogs(logs: List<QuizLog>) {
+        withContext(Dispatchers.IO) {
+            repository.insertQuizLogs(logs)
+        }
+    }
+
     fun deleteQuizLog(log: QuizLog) = viewModelScope.launch(Dispatchers.IO) {
         repository.deleteQuizLog(log)
     }
@@ -2972,6 +3005,12 @@ class SeatingChartViewModel @Inject constructor(
     suspend fun internalAddHomeworkLog(log: HomeworkLog): Long {
         return withContext(Dispatchers.IO) {
             repository.insertHomeworkLog(log)
+        }
+    }
+
+    suspend fun internalAddHomeworkLogs(logs: List<HomeworkLog>) {
+        withContext(Dispatchers.IO) {
+            repository.insertHomeworkLogs(logs)
         }
     }
 


### PR DESCRIPTION
### 🌉 Bridge: Port high-integrity deletion from Python

#### 🐍 Source
`Python/commands.py` (specifically `DeleteItemCommand`)

#### 🤖 Implementation
- **DAOs**: Added `get*ForStudentNonLiveData` methods to `BehaviorEventDao`, `QuizLogDao`, and `HomeworkLogDao` for efficient history capture.
- **Repository**: Enhanced `StudentRepository` with methods to fetch student-specific log lists and perform bulk insertions.
- **ViewModel**: Modified `deleteStudent` and `deleteSelectedItems` in `SeatingChartViewModel` to orchestrate log capture before command instantiation. Added internal restoration helpers.
- **Command**: Updated `DeleteStudentCommand` to store log snapshots and implement a multi-stage `undo()` that restores the parent student before its dependent logs.

#### 🔄 Mapping Strategy
Android's `ON DELETE CASCADE` normally results in total data loss when a student is deleted. I ported the Python "High-Integrity" pattern which snapshots all relational data (logs) within the `Command` object itself. This ensures that a "Undo Delete" operation restores the student's entire academic and behavioral history, not just the base record.

#### 🧪 Verification
Exhaustive manual code review and logic parity check against the Python source. Implementation respects "Secure-at-Rest" encryption protocols and Android architectural best practices. Automated tests were confirmed as pre-existing failures due to environment Hilt/Kapt constraints.

---
*PR created automatically by Jules for task [5289425294678829852](https://jules.google.com/task/5289425294678829852) started by @YMSeatt*