### PR TITLE
⚡ Bolt: [Optimization] in Ghost Rain Physics

### DIFF
--- a/app/src/main/java/com/example/myapplication/labs/ghost/rain/GhostRainEngine.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/rain/GhostRainEngine.kt
@@ -60,6 +60,20 @@ class GhostRainEngine {
         // Base spawn rate + activity bonus
         val spawnProbability = (0.05f + (activityCount.toFloat() / 50f)).coerceAtMost(0.8f)
 
+        // BOLT: Hoist student positions and dimensions to avoid O(D * S) MutableState reads
+        val sCount = students.size
+        val sX = FloatArray(sCount)
+        val sY = FloatArray(sCount)
+        val sW = FloatArray(sCount)
+        val sH = FloatArray(sCount)
+        for (j in 0 until sCount) {
+            val s = students[j]
+            sX[j] = s.xPosition.value
+            sY[j] = s.yPosition.value
+            sW[j] = s.displayWidth.value.value * 20f // Rough Dp to logical conversion
+            sH[j] = s.displayHeight.value.value * 20f
+        }
+
         // 2. Physics & Intersection Loop
         for (i in 0 until MAX_DROPLETS) {
             if (dropActive[i]) {
@@ -75,15 +89,11 @@ class GhostRainEngine {
                     dropVel[i] += GRAVITY * dt
 
                     // Intersection Check (Student Icons)
-                    for (j in students.indices) {
-                        val s = students[j]
-                        val sx = s.xPosition.value
-                        val sy = s.yPosition.value
-                        val sw = s.displayWidth.value.value * 20f // Rough Dp to logical conversion
-                        val sh = s.displayHeight.value.value * 20f
-
-                        if (dropX[i] >= sx && dropX[i] <= sx + sw &&
-                            dropY[i] >= sy && dropY[i] <= sy + sh) {
+                    val dx = dropX[i]
+                    val dy = dropY[i]
+                    for (j in 0 until sCount) {
+                        if (dx >= sX[j] && dx <= sX[j] + sW[j] &&
+                            dy >= sY[j] && dy <= sY[j] + sH[j]) {
                             splashTime[i] = 0.01f
                             break
                         }

--- a/app/src/main/java/com/example/myapplication/labs/ghost/rain/GhostRainLayer.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/rain/GhostRainLayer.kt
@@ -43,9 +43,12 @@ fun GhostRainLayer(
 
     // Physics Update Loop (60fps)
     LaunchedEffect(isActive, students, behaviorLogs) {
-        while (isActive) {
-            engine.update(students, behaviorLogs)
-            delay(16)
+        // BOLT: Offload physics update to Default dispatcher
+        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
+            while (isActive) {
+                engine.update(students, behaviorLogs)
+                delay(16)
+            }
         }
     }
 


### PR DESCRIPTION
⚡ Bolt: [Optimization] in Ghost Rain Physics

🐢 The Bottleneck:
GhostRainEngine was performing O(MAX_DROPLETS * S) MutableState reads in its 60fps physics update loop. Reading MutableState in Compose involves snapshot observation overhead, which added up to significant CPU churn and potential frame drops when many students were on the canvas. Additionally, the physics loop was running on the Main thread.

🐇 The Fix:
- Hoisted student positions and dimensions into local primitive FloatArrays once per frame at the start of the update() method.
- Replaced the nested student loop's MutableState reads with O(1) primitive array lookups.
- Offloaded the entire LaunchedEffect physics loop to Dispatchers.Default using withContext in GhostRainLayer.kt.

📉 The Impact:
- Eliminated redundant snapshot observation overhead during collision detection.
- Freed up the Main thread from expensive physics calculations, ensuring smoother 60fps interaction during the 'Neural Rain' simulation.

---
*PR created automatically by Jules for task [5772279012551064796](https://jules.google.com/task/5772279012551064796) started by @YMSeatt*