### PR TITLE
🛡️ Shield: Unified Privacy Shield for Voice Assistant

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -140,3 +140,11 @@
 - **Vulnerability:** The experimental "Neural Spectroscopy" report contained raw student names in the Markdown output and intent subjects, potentially leaking PII to external applications and unencrypted system logs.
 - **Fix:** Implemented PII masking using the `maskStudentName` utility for all student entries in `GhostSpectraEngine.kt` and for intent subjects in `GhostSpectraDialog.kt`.
 - **Location:** `app/src/main/java/com/example/myapplication/labs/ghost/GhostSpectraEngine.kt`, `app/src/main/java/com/example/myapplication/labs/ghost/GhostSpectraDialog.kt`
+
+## 🛡️ Privacy Hardening: Unified Privacy Shield for Voice Assistant
+- **Vulnerability:** Voice transcriptions (containing student names/PII) persisted on the screen indefinitely after speech ended. Furthermore, the `FLAG_SECURE` protection (Privacy Shield) was tied only to the active microphone state, leaving PII exposed to screen capture during the result-display window.
+- **Fix:**
+    - Implemented a **Unified Privacy Shield** in `SeatingChartScreen.kt` that monitors both the listening state and the presence of transcribed text.
+    - Added an automatic **State Purge** mechanism via `LaunchedEffect` that clears transcribed PII from memory after a 5-second timeout.
+    - Updated `GhostVoiceVisualizer.kt` to allow persistent feedback during the timeout period while suppressing expensive shader animations when the microphone is inactive.
+- **Location:** `app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt`, `app/src/main/java/com/example/myapplication/labs/ghost/GhostVisualizer.kt`

--- a/app/src/main/java/com/example/myapplication/labs/ghost/GhostVisualizer.kt
+++ b/app/src/main/java/com/example/myapplication/labs/ghost/GhostVisualizer.kt
@@ -33,7 +33,9 @@ fun GhostVoiceVisualizer(
     currentText: String,
     modifier: Modifier = Modifier
 ) {
-    if (!GhostConfig.GHOST_MODE_ENABLED || !isListening) return
+    // HARDEN: Allow visualizer to remain active if there is still text to display,
+    // ensuring the teacher can see the final command result under Privacy Shield.
+    if (!GhostConfig.GHOST_MODE_ENABLED || (!isListening && currentText.isEmpty())) return
 
     val infiniteTransition = rememberInfiniteTransition(label = "voiceWave")
     val time by infiniteTransition.animateFloat(
@@ -53,7 +55,7 @@ fun GhostVoiceVisualizer(
     )
 
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && isListening) {
             val color = MaterialTheme.colorScheme.tertiary
             val shader = remember { RuntimeShader(GhostShader.VOICE_WAVEFORM) }
             val brush = remember(shader) { ShaderBrush(shader) }

--- a/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
+++ b/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
@@ -548,6 +548,14 @@ fun SeatingChartScreen(
     var ghostAmplitude by remember { mutableFloatStateOf(0f) }
     var ghostCurrentText by remember { mutableStateOf("") }
 
+    // HARDEN: Automatically clear transcribed PII after a short timeout
+    LaunchedEffect(isGhostListening, ghostCurrentText) {
+        if (!isGhostListening && ghostCurrentText.isNotEmpty()) {
+            delay(5000)
+            ghostCurrentText = ""
+        }
+    }
+
     val ghostVoiceAssistant = remember(behaviorTypeNames) {
         GhostVoiceAssistant(
             context = context,
@@ -613,7 +621,7 @@ fun SeatingChartScreen(
                                    isHaloActive || isTraceActive || isCarbonActive || isWeaverActive ||
                                    isFrostActive || isRadarActive || isOrigamiActive || isSonarActive ||
                                    isBeaconActive || isSpotlightActive || isStrategistActive || isDeckActive ||
-                                   isGhostListening || isStudentHubVisible || (activeGlanceStudentId != null) ||
+                                   isGhostListening || ghostCurrentText.isNotEmpty() || isStudentHubVisible || (activeGlanceStudentId != null) ||
                                    showGhostInsightDialog || showGhostSynapseDialog || showGhostSpectraDialog ||
                                    showGhostOracleDialog || showBehaviorDialog || showLogQuizScoreDialog ||
                                    showLiveQuizMarkDialog || showAdvancedHomeworkLogDialog ||


### PR DESCRIPTION
🔓 *The Vulnerability:* Voice transcriptions containing student names and behavioral logs (PII) persisted on the screen indefinitely after speech ended. Additionally, the `FLAG_SECURE` protection (Privacy Shield) was tied strictly to the active microphone state, leaving PII exposed to unauthorized screen capture during the critical window when a teacher reads the recognized command.

🔐 *The Fix:* 
1. Implemented a **Unified Privacy Shield** in `SeatingChartScreen.kt` that monitors both the listening state and the presence of transcribed text to keep `FLAG_SECURE` active.
2. Added a **State Purge** mechanism using a `LaunchedEffect` with a 5000ms delay to automatically wipe sensitive transcriptions from the UI state.
3. Updated `GhostVoiceVisualizer.kt` to allow the component to remain visible while text is present, providing necessary feedback to the teacher, while explicitly disabling the expensive AGSL sine-wave shader when the microphone is off.

📜 *Compliance:* This aligns with Google Play's PII protection standards and OWASP Mobile Top 10 (M4: Insecure Data Storage / M1: Improper Platform Usage).

---
*PR created automatically by Jules for task [2139046117065167595](https://jules.google.com/task/2139046117065167595) started by @YMSeatt*