### PR TITLE
🛡️ Shield: Security Hardening in Cryptographic Layer

### DIFF
--- a/app/src/main/java/com/example/myapplication/data/importer/Importer.kt
+++ b/app/src/main/java/com/example/myapplication/data/importer/Importer.kt
@@ -98,22 +98,11 @@ class Importer(
 
     /**
      * Utility to read asset files, handling decryption automatically if required.
-     * Falls back to plaintext if decryption fails, allowing for a mix of secure and insecure sources.
      */
     private suspend fun readAssetFile(fileName: String): String? {
         return try {
             val bytes = context.assets.open(fileName).use { it.readBytes() }
-
-            if (encryptDataFilesFlow.first()) {
-                try {
-                    securityUtil.decrypt(String(bytes, Charsets.UTF_8))
-                } catch (e: Exception) {
-                    // If decryption fails, assume it's plaintext
-                    String(bytes, Charsets.UTF_8)
-                }
-            } else {
-                String(bytes, Charsets.UTF_8)
-            }
+            decryptInboundData(String(bytes, Charsets.UTF_8))
         } catch (e: IOException) {
             Log.e("Importer", "Error reading asset file: $fileName", e)
             null
@@ -152,21 +141,36 @@ class Importer(
                 }
 
                 if (bytes != null) {
-                    val jsonString = if (encryptDataFilesFlow.first()) {
-                        try {
-                            securityUtil.decrypt(String(bytes, Charsets.UTF_8))
-                        } catch (e: Exception) {
-                            // If decryption fails, assume it's plaintext
-                            String(bytes, Charsets.UTF_8)
-                        }
-                    } else {
-                        String(bytes, Charsets.UTF_8)
-                    }
+                    val jsonString = decryptInboundData(String(bytes, Charsets.UTF_8))
                     importClassroomDataFromJson(jsonString)
                 }
             } catch (e: Exception) {
                 Log.e("Importer", "Error during import from URI", e)
             }
+        }
+    }
+
+    /**
+     * Tiered decryption for inbound data (imports/assets).
+     * Attempts modern decryption first, then legacy decryption for Python compatibility,
+     * and finally defaults to plaintext if all decryption attempts fail.
+     */
+    private suspend fun decryptInboundData(rawContent: String): String {
+        return if (encryptDataFilesFlow.first()) {
+            try {
+                // Try modern decryption first (hardware-backed key)
+                securityUtil.decrypt(rawContent)
+            } catch (e: Exception) {
+                try {
+                    // FALLBACK: Attempt legacy decryption for Python cross-platform parity
+                    securityUtil.decryptLegacy(rawContent)
+                } catch (le: Exception) {
+                    // If all decryption fails, assume it's plaintext
+                    rawContent
+                }
+            }
+        } else {
+            rawContent
         }
     }
 

--- a/app/src/main/java/com/example/myapplication/util/SecurityUtil.kt
+++ b/app/src/main/java/com/example/myapplication/util/SecurityUtil.kt
@@ -338,29 +338,40 @@ class SecurityUtil @Inject constructor(@ApplicationContext context: Context) {
     }
 
     /**
-     * Decrypts a Fernet token into a UTF-8 string. It first tries to decrypt with the new, secure key.
-     * If that fails, it falls back to the old, hardcoded key to support data migration.
+     * Decrypts a Fernet token into a UTF-8 string using the modern hardware-backed key.
      */
     fun decrypt(token: String): String {
         return String(decryptToByteArray(token), Charsets.UTF_8)
     }
 
     /**
-     * Decrypts a Fernet token into a byte array. It first tries to decrypt with the new, secure key.
-     * If that fails, it falls back to the old, hardcoded key to support data migration.
+     * Decrypts a Fernet token into a byte array using the modern hardware-backed key.
+     * Unlike legacy decryption, this method does NOT fall back to the hardcoded shared secret.
      */
     fun decryptToByteArray(token: String): ByteArray {
+        return fernetCipher.decrypt(token, TTL_SECONDS)
+    }
+
+    /**
+     * Decrypts a Fernet token into a byte array using the legacy fallback key.
+     *
+     * **Security Warning**: This method uses a hardcoded shared secret and should be used
+     * strictly for ingestion of external data from the Python desktop application.
+     * Standard application data should use [decrypt].
+     */
+    fun decryptLegacyToByteArray(token: String): ByteArray {
+        val oldToken = Token.fromString(token)
+        return oldToken.validateAndDecrypt(FALLBACK_KEY, ByteArrayValidator())
+    }
+
+    /**
+     * Decrypts a Fernet token into a UTF-8 string using the legacy fallback key.
+     */
+    fun decryptLegacy(token: String): String {
         return try {
-            fernetCipher.decrypt(token, TTL_SECONDS)
+            String(decryptLegacyToByteArray(token), Charsets.UTF_8)
         } catch (e: Exception) {
-            // If the token is valid but expired, do NOT fall back to the legacy key.
-            // This ensures we respect the TTL for primary security.
-            if (e is TokenExpiredException) {
-                throw e
-            }
-            // Fallback to old key
-            val oldToken = Token.fromString(token)
-            oldToken.validateAndDecrypt(FALLBACK_KEY, ByteArrayValidator())
+            throw SecurityException("Legacy decryption failed", e)
         }
     }
 

--- a/app/src/test/java/com/example/myapplication/util/SecurityUtilTest.kt
+++ b/app/src/test/java/com/example/myapplication/util/SecurityUtilTest.kt
@@ -102,12 +102,21 @@ class SecurityUtilTest {
     }
 
     @Test
-    fun `test fallback decryption`() {
+    fun `test legacy decryption`() {
         val originalText = "This is a secret message."
         val oldKey = Key("7-BH7qsnKyRK0jdAZrjXSIW9VmcdpfHHeZor0ACBkmU=")
         val oldToken = Token.generate(oldKey, originalText)
-        val decryptedText = securityUtil.decrypt(oldToken.serialise())
-        assertEquals("Decrypted text should match original text", originalText, decryptedText)
+        val decryptedText = securityUtil.decryptLegacy(oldToken.serialise())
+        assertEquals("Legacy decrypted text should match original text", originalText, decryptedText)
+    }
+
+    @Test(expected = Exception::class)
+    fun `test standard decryption should fail for legacy token`() {
+        val originalText = "This is a secret message."
+        val oldKey = Key("7-BH7qsnKyRK0jdAZrjXSIW9VmcdpfHHeZor0ACBkmU=")
+        val oldToken = Token.generate(oldKey, originalText)
+        // This should now throw an exception because standard decrypt no longer falls back to the legacy key
+        securityUtil.decrypt(oldToken.serialise())
     }
 
     @Test


### PR DESCRIPTION
🔓 *The Vulnerability:* The `SecurityUtil.kt` utility previously performed an automatic and silent fallback to a hardcoded legacy key (`FALLBACK_KEY`) whenever standard decryption failed. This meant that all application data, including student PII and academic records, was effectively vulnerable to decryption using a weak, non-hardware-backed secret if the primary key failed or if data was inadvertently associated with the legacy path.

🔐 *The Fix:* I have hardened the cryptographic boundary by implementing the following:
1. **Isolation**: Standard `decrypt` and `decryptToByteArray` methods now strictly utilize the hardware-backed `fernetCipher`. Automatic fallback has been removed.
2. **Explicit Legacy Path**: New `decryptLegacy` methods provide a dedicated, auditable path for using the hardcoded key.
3. **Tiered Ingestion**: `Importer.kt` now explicitly manages the transition between modern, legacy, and plaintext data during imports, preventing the "leakage" of the legacy secret into general application logic.
4. **Test Hardening**: Updated the unit test suite to ensure that standard decryption correctly fails when presented with legacy tokens, verifying the enforcement of the new security policy.

📜 *Compliance:* This aligns with defense-in-depth principles and Google Play data safety requirements by ensuring that modern user data is exclusively protected by hardware-backed keys and that hardcoded secrets are never used as a general-purpose recovery mechanism.

---
*PR created automatically by Jules for task [17711139896675670752](https://jules.google.com/task/17711139896675670752) started by @YMSeatt*