### PR TITLE
🌉 Bridge: Port Live Session Marking logic from Python

### DIFF
--- a/app/src/main/java/com/example/myapplication/ui/dialogs/LiveHomeworkMarkDialog.kt
+++ b/app/src/main/java/com/example/myapplication/ui/dialogs/LiveHomeworkMarkDialog.kt
@@ -1,20 +1,30 @@
 package com.example.myapplication.ui.dialogs
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
@@ -31,6 +41,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.example.myapplication.data.HomeworkLog
 import com.example.myapplication.data.HomeworkMarkType
@@ -47,34 +58,50 @@ fun LiveHomeworkMarkDialog(
     viewModel: SeatingChartViewModel,
     settingsViewModel: com.example.myapplication.viewmodel.SettingsViewModel,
     onDismissRequest: () -> Unit,
-    onSave: (HomeworkLog) -> Unit
+    onSave: (List<HomeworkLog>) -> Unit
 ) {
     var student by remember { mutableStateOf<Student?>(null) }
     val liveHomeworkSessionMode by settingsViewModel.liveHomeworkSessionMode.collectAsState()
     val liveHomeworkSelectOptions by settingsViewModel.liveHomeworkSelectOptions.collectAsState()
     val allTemplates by viewModel.allHomeworkTemplates.observeAsState(emptyList())
+    val customHomeworkTypes by settingsViewModel.customHomeworkTypes.observeAsState(initial = emptyList())
     
-    // State for template mode
-    var selectedTemplate by remember { mutableStateOf<HomeworkTemplate?>(null) }
-    var templateExpanded by remember { mutableStateOf(false) }
-    val markValues = remember { mutableStateMapOf<String, Any>() } // stepId -> value
+    // State for session tracking
+    val yesNoStates = remember { mutableStateMapOf<String, String>() } // TypeName -> "yes"/"no"/"pending"
+    val selectStates = remember { mutableStateMapOf<String, Boolean>() } // OptionName -> selected
 
-    // Initialize mark values when template changes
-    LaunchedEffect(selectedTemplate) {
-        markValues.clear()
-        selectedTemplate?.getSteps()?.forEach { step ->
-             // Use label as key for readability
-             val key = step.label
-            when (step.type) {
-                HomeworkMarkType.CHECKBOX -> markValues[key] = false
-                HomeworkMarkType.SCORE -> markValues[key] = 0 // Default score
-                HomeworkMarkType.COMMENT -> markValues[key] = ""
+    // Initialize states from current session data if available
+    LaunchedEffect(studentId, viewModel.liveHomeworkScores.value) {
+        student = viewModel.getStudentForEditing(studentId)
+        val currentScores = viewModel.liveHomeworkScores.value?.get(studentId) ?: emptyMap()
+
+        if (liveHomeworkSessionMode == "Select") {
+            val selected = currentScores["selected_options"] as? List<*> ?: emptyList()
+            liveHomeworkSelectOptions.split(",").forEach { option ->
+                selectStates[option.trim()] = selected.contains(option.trim())
+            }
+        } else {
+            customHomeworkTypes.forEach { type ->
+                yesNoStates[type.name] = currentScores[type.name]?.toString() ?: "pending"
             }
         }
     }
 
-    LaunchedEffect(studentId) {
-        student = viewModel.getStudentForEditing(studentId)
+    // Template Mode state
+    var selectedTemplate by remember { mutableStateOf<HomeworkTemplate?>(null) }
+    var templateExpanded by remember { mutableStateOf(false) }
+    val markValues = remember { mutableStateMapOf<String, Any>() }
+
+    LaunchedEffect(selectedTemplate) {
+        markValues.clear()
+        selectedTemplate?.getSteps()?.forEach { step ->
+             val key = step.label
+            when (step.type) {
+                HomeworkMarkType.CHECKBOX -> markValues[key] = false
+                HomeworkMarkType.SCORE -> markValues[key] = 0
+                HomeworkMarkType.COMMENT -> markValues[key] = ""
+            }
+        }
     }
 
     AlertDialog(
@@ -82,9 +109,6 @@ fun LiveHomeworkMarkDialog(
         title = { Text(student?.let { "Mark Homework for ${it.firstName} ${it.lastName}" } ?: "Mark Homework") },
         text = {
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                Text(student?.let { "Mark ${it.firstName}'s homework:" } ?: "Mark this student's homework:")
-                Spacer(modifier = Modifier.height(16.dp))
-
                 // Template Selector
                 if (allTemplates.isNotEmpty()) {
                     ExposedDropdownMenuBox(
@@ -126,7 +150,6 @@ fun LiveHomeworkMarkDialog(
                 }
 
                 if (selectedTemplate != null) {
-                    // Template Based Marking
                     val steps = selectedTemplate!!.getSteps()
                     steps.forEach { step ->
                         Text(step.label, style = MaterialTheme.typography.labelLarge, modifier = Modifier.padding(top=8.dp))
@@ -151,7 +174,7 @@ fun LiveHomeworkMarkDialog(
                                             markValues[key] = it.roundToInt() 
                                         },
                                         valueRange = 0f..step.maxValue.toFloat(),
-                                        steps = if (step.maxValue > 0) step.maxValue - 1 else 0
+                                        steps = if (step.maxValue > 1) step.maxValue - 1 else 0
                                     )
                                     Text("Score: ${score.roundToInt()} / ${step.maxValue}")
                                 }
@@ -165,81 +188,111 @@ fun LiveHomeworkMarkDialog(
                             }
                         }
                     }
-
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Button(
-                        onClick = {
-                            val log = HomeworkLog(
-                                studentId = studentId,
-                                assignmentName = selectedTemplate!!.name, // Use template name as assignment name
-                                status = "Completed", // Or derive from marks
-                                loggedAt = System.currentTimeMillis(),
-                                marksData = Gson().toJson(markValues),
-                                isComplete = true
-                            )
-                            onSave(log)
-                            onDismissRequest()
-                        },
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text("Save Marks")
-                    }
-
                 } else {
-                    // Legacy / Quick Mark Mode
+                    // Quick Mark Mode
                     if (liveHomeworkSessionMode == "Select") {
                         val options = liveHomeworkSelectOptions.split(",").filter { it.isNotBlank() }
                         options.forEach { option ->
-                            Button(
-                                onClick = {
-                                    val log = HomeworkLog(
-                                        studentId = studentId,
-                                        assignmentName = "Live Homework",
-                                        status = option.trim(),
-                                        loggedAt = System.currentTimeMillis(),
-                                        marksData = "{}"
-                                    )
-                                    onSave(log)
-                                    onDismissRequest()
-                                },
-                                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                            val trimmed = option.trim()
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.SpaceBetween
                             ) {
-                                Text(option.trim())
+                                Text(trimmed)
+                                Checkbox(
+                                    checked = selectStates[trimmed] ?: false,
+                                    onCheckedChange = { selectStates[trimmed] = it }
+                                )
                             }
+                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                         }
                     } else {
-                        Button(onClick = {
-                            val log = HomeworkLog(
-                                studentId = studentId,
-                                assignmentName = "Live Homework",
-                                status = "Done",
-                                loggedAt = System.currentTimeMillis(),
-                                marksData = "{}"
-                            )
-                            onSave(log)
-                            onDismissRequest()
-                        }, modifier = Modifier.fillMaxWidth()) {
-                            Text("Done")
+                        // Yes/No Mode
+                        if (customHomeworkTypes.isEmpty()) {
+                            Text("No homework types configured for 'Yes/No' mode.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.error)
                         }
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Button(onClick = {
-                            val log = HomeworkLog(
-                                studentId = studentId,
-                                assignmentName = "Live Homework",
-                                status = "Not Done",
-                                loggedAt = System.currentTimeMillis(),
-                                marksData = "{}"
-                            )
-                            onSave(log)
-                            onDismissRequest()
-                        }, modifier = Modifier.fillMaxWidth()) {
-                            Text("Not Done")
+                        customHomeworkTypes.forEach { type ->
+                            val state = yesNoStates[type.name] ?: "pending"
+                            Row(
+                                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Text(type.name, modifier = Modifier.weight(1f))
+                                Row {
+                                    IconButton(
+                                        onClick = { yesNoStates[type.name] = if (state == "yes") "pending" else "yes" },
+                                        colors = IconButtonDefaults.iconButtonColors(
+                                            containerColor = if (state == "yes") Color(0xFF4CAF50) else Color.Transparent,
+                                            contentColor = if (state == "yes") Color.White else MaterialTheme.colorScheme.onSurface
+                                        )
+                                    ) {
+                                        Icon(Icons.Default.Check, contentDescription = "Yes")
+                                    }
+                                    IconButton(
+                                        onClick = { yesNoStates[type.name] = if (state == "no") "pending" else "no" },
+                                        colors = IconButtonDefaults.iconButtonColors(
+                                            containerColor = if (state == "no") Color(0xFFF44336) else Color.Transparent,
+                                            contentColor = if (state == "no") Color.White else MaterialTheme.colorScheme.onSurface
+                                        )
+                                    ) {
+                                        Icon(Icons.Default.Close, contentDescription = "No")
+                                    }
+                                }
+                            }
+                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                         }
                     }
                 }
             }
         },
         confirmButton = {
+            Button(
+                onClick = {
+                    val logs = mutableListOf<HomeworkLog>()
+                    if (selectedTemplate != null) {
+                        logs.add(HomeworkLog(
+                            studentId = studentId,
+                            assignmentName = selectedTemplate!!.name,
+                            status = "Completed",
+                            loggedAt = System.currentTimeMillis(),
+                            marksData = Gson().toJson(markValues),
+                            isComplete = true
+                        ))
+                    } else {
+                        if (liveHomeworkSessionMode == "Select") {
+                            val selected = selectStates.filter { it.value }.keys.toList()
+                            logs.add(HomeworkLog(
+                                studentId = studentId,
+                                assignmentName = "selected_options", // Key for ConditionalFormattingEngine
+                                status = "Session Update",
+                                loggedAt = System.currentTimeMillis(),
+                                marksData = Gson().toJson(mapOf("selected_options" to selected))
+                            ))
+                        } else {
+                            // Yes/No mode: return multiple logs or one aggregated?
+                            // To match ConditionalFormattingEngine expectations, we aggregate.
+                            val aggregated = yesNoStates.filter { it.value != "pending" }
+                            if (aggregated.isNotEmpty()) {
+                                logs.add(HomeworkLog(
+                                    studentId = studentId,
+                                    assignmentName = "Yes/No Update",
+                                    status = "Session Update",
+                                    loggedAt = System.currentTimeMillis(),
+                                    marksData = Gson().toJson(aggregated)
+                                ))
+                            }
+                        }
+                    }
+                    onSave(logs)
+                    onDismissRequest()
+                }
+            ) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
             TextButton(onClick = onDismissRequest) {
                 Text("Cancel")
             }

--- a/app/src/main/java/com/example/myapplication/ui/dialogs/LiveQuizMarkDialog.kt
+++ b/app/src/main/java/com/example/myapplication/ui/dialogs/LiveQuizMarkDialog.kt
@@ -2,9 +2,11 @@ package com.example.myapplication.ui.dialogs
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -27,6 +29,9 @@ fun LiveQuizMarkDialog(
     onSave: (QuizLog) -> Unit
 ) {
     var student by remember { mutableStateOf<Student?>(null) }
+    val currentScore = remember(viewModel.liveQuizScores.value) {
+        viewModel.liveQuizScores.value?.get(studentId) ?: emptyMap()
+    }
 
     LaunchedEffect(studentId) {
         student = viewModel.getStudentForEditing(studentId)
@@ -37,42 +42,73 @@ fun LiveQuizMarkDialog(
         title = { Text(student?.let { "Mark Quiz for ${it.firstName} ${it.lastName}" } ?: "Mark Quiz") },
         text = {
             Column {
-                Text(student?.let { "Mark ${it.firstName}'s answer:" } ?: "Mark this student's answer:")
+                val correct = currentScore["correct"] as? Int ?: 0
+                val total = currentScore["total_asked"] as? Int ?: 0
+                Text("Current Score: $correct / $total", style = MaterialTheme.typography.titleMedium)
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(student?.let { "Mark ${it.firstName}'s next answer:" } ?: "Mark this student's next answer:")
                 Spacer(modifier = Modifier.height(16.dp))
-                Button(onClick = {
-                    val log = QuizLog(
-                        studentId = studentId,
-                        quizName = "Live Quiz",
-                        loggedAt = System.currentTimeMillis(),
-                        comment = "Correct",
-                        marksData = "{\"Correct\": 1}",
-                        markValue = 1.0,
-                        markType = "Correct",
-                        maxMarkValue = 1.0,
-                        numQuestions = 1
-                    )
-                    onSave(log)
-                    onDismissRequest()
-                }) {
+                Button(
+                    onClick = {
+                        val log = QuizLog(
+                            studentId = studentId,
+                            quizName = "Live Quiz",
+                            loggedAt = System.currentTimeMillis(),
+                            comment = "Correct",
+                            marksData = "{\"Correct\": 1}",
+                            markValue = 1.0,
+                            markType = "Correct",
+                            maxMarkValue = 1.0,
+                            numQuestions = 1
+                        )
+                        onSave(log)
+                        onDismissRequest()
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
                     Text("Correct")
                 }
                 Spacer(modifier = Modifier.height(8.dp))
-                Button(onClick = {
-                    val log = QuizLog(
-                        studentId = studentId,
-                        quizName = "Live Quiz",
-                        loggedAt = System.currentTimeMillis(),
-                        comment = "Incorrect",
-                        marksData = "{\"Incorrect\": 1}",
-                        markValue = 0.0,
-                        markType = "Incorrect",
-                        maxMarkValue = 1.0,
-                        numQuestions = 1
-                    )
-                    onSave(log)
-                    onDismissRequest()
-                }) {
+                Button(
+                    onClick = {
+                        val log = QuizLog(
+                            studentId = studentId,
+                            quizName = "Live Quiz",
+                            loggedAt = System.currentTimeMillis(),
+                            comment = "Incorrect",
+                            marksData = "{\"Incorrect\": 1}",
+                            markValue = 0.0,
+                            markType = "Incorrect",
+                            maxMarkValue = 1.0,
+                            numQuestions = 1
+                        )
+                        onSave(log)
+                        onDismissRequest()
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
                     Text("Incorrect")
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(
+                    onClick = {
+                        val log = QuizLog(
+                            studentId = studentId,
+                            quizName = "Live Quiz",
+                            loggedAt = System.currentTimeMillis(),
+                            comment = "Skip",
+                            marksData = "{\"Skip\": 1}",
+                            markValue = 0.0,
+                            markType = "Skip",
+                            maxMarkValue = 1.0,
+                            numQuestions = 1 // Increments total_asked to match Python logic
+                        )
+                        onSave(log)
+                        onDismissRequest()
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Skip / Pass")
                 }
             }
         },

--- a/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
+++ b/app/src/main/java/com/example/myapplication/ui/screens/SeatingChartScreen.kt
@@ -2110,7 +2110,7 @@ fun SeatingChartScreen(
                         viewModel = seatingChartViewModel,
                         settingsViewModel = settingsViewModel,
                         onDismissRequest = { showLiveHomeworkMarkDialog = false; selectedStudentUiItemForAction = null },
-                        onSave = { homeworkLog -> seatingChartViewModel.addHomeworkLogToSession(homeworkLog) }
+                        onSave = { homeworkLogs -> seatingChartViewModel.addHomeworkLogsToSession(homeworkLogs) }
                     )
                 }
             }

--- a/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
@@ -1773,25 +1773,57 @@ class SeatingChartViewModel @Inject constructor(
 
                         val sessionLogs = if (sessionActive) {
                             val sLogs = ArrayList<String>(maxLogsToDisplay)
-                            val qLogsSess = sessionQuizLogsGrouped[student.id]
-                            if (qLogsSess != null) {
-                                for (i in 0 until qLogsSess.size) {
-                                    if (sLogs.size >= maxLogsToDisplay) break
-                                    sLogs.add("Quiz: ${qLogsSess[i].comment}")
+                            if (currentModeValue == "quiz") {
+                                val scoreInfo = liveQuizScoresSnapshot[student.id]
+                                if (scoreInfo != null) {
+                                    val correct = scoreInfo["correct"] as? Int ?: 0
+                                    val total = scoreInfo["total_asked"] as? Int ?: 0
+                                    sLogs.add("Quiz: $correct of $total")
+                                } else {
+                                    sLogs.add("Quiz: (Pending)")
+                                }
+                            } else if (currentModeValue == "homework") {
+                                val hwData = liveHomeworkScoresSnapshot[student.id]
+                                if (hwData != null) {
+                                    val selected = hwData["selected_options"] as? List<*>
+                                    if (selected != null) {
+                                        selected.forEach { opt ->
+                                            if (sLogs.size < maxLogsToDisplay) sLogs.add(opt.toString())
+                                        }
+                                    } else {
+                                        hwData.forEach { (name, status) ->
+                                            if (name != "selected_options" && sLogs.size < maxLogsToDisplay) {
+                                                sLogs.add("$name: $status")
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    sLogs.add("Homework: (Pending)")
                                 }
                             }
-                            val hLogsSess = sessionHomeworkLogsGrouped[student.id]
-                            if (hLogsSess != null) {
-                                for (i in 0 until hLogsSess.size) {
-                                    if (sLogs.size >= maxLogsToDisplay) break
-                                    val log = hLogsSess[i]
-                                    val status = log.status
-                                    val statusDescription = if (useInitialsForHomework) {
-                                        homeworkInitialsMap[status] ?: status.generateLogInitials().ifEmpty { "?" }
-                                    } else {
-                                        status
+
+                            // Fallback: If no dedicated session summary was added, show recent session logs
+                            if (sLogs.isEmpty()) {
+                                val qLogsSess = sessionQuizLogsGrouped[student.id]
+                                if (qLogsSess != null) {
+                                    for (i in 0 until qLogsSess.size) {
+                                        if (sLogs.size >= maxLogsToDisplay) break
+                                        sLogs.add("Quiz: ${qLogsSess[i].comment}")
                                     }
-                                    sLogs.add("${log.assignmentName}: $statusDescription")
+                                }
+                                val hLogsSess = sessionHomeworkLogsGrouped[student.id]
+                                if (hLogsSess != null) {
+                                    for (i in 0 until hLogsSess.size) {
+                                        if (sLogs.size >= maxLogsToDisplay) break
+                                        val log = hLogsSess[i]
+                                        val status = log.status
+                                        val statusDescription = if (useInitialsForHomework) {
+                                            homeworkInitialsMap[status] ?: status.generateLogInitials().ifEmpty { "?" }
+                                        } else {
+                                            status
+                                        }
+                                        sLogs.add("${log.assignmentName}: $statusDescription")
+                                    }
                                 }
                             }
                             sLogs
@@ -3296,6 +3328,8 @@ class SeatingChartViewModel @Inject constructor(
                 // Clear the session data
                 sessionQuizLogs.postValue(emptyList())
                 sessionHomeworkLogs.postValue(emptyList())
+                liveQuizScores.postValue(emptyMap())
+                liveHomeworkScores.postValue(emptyMap())
                 isSessionActive.postValue(false)
             }
         }
@@ -3315,15 +3349,10 @@ class SeatingChartViewModel @Inject constructor(
     fun addQuizLogToSession(quizLog: QuizLog) {
         if (isSessionActive.value == true) {
             val currentLogs = sessionQuizLogs.value.orEmpty().toMutableList()
-            val existingLogIndex = currentLogs.indexOfFirst {
-                it.studentId == quizLog.studentId && it.quizName == quizLog.quizName
-            }
-
-            if (existingLogIndex != -1) {
-                currentLogs[existingLogIndex] = quizLog
-            } else {
-                currentLogs.add(quizLog)
-            }
+            // In a session, we usually want to KEEP all marks, but for simple progress tracking
+            // we treat marks for the SAME quiz name as updates if they are from the same "session".
+            // However, to match Python keypad behavior, we append.
+            currentLogs.add(quizLog)
             sessionQuizLogs.postValue(currentLogs)
 
             // Update live scores for immediate UI feedback
@@ -3334,12 +3363,14 @@ class SeatingChartViewModel @Inject constructor(
             studentScores["marks_data"] = quizLog.marksData
 
             // Aggregate session progress (Ported from Python)
-            val totalAsked = (studentScores["total_asked"] as? Int ?: 0) + 1
-            studentScores["total_asked"] = totalAsked
+            if (quizLog.numQuestions > 0) {
+                val totalAsked = (studentScores["total_asked"] as? Int ?: 0) + 1
+                studentScores["total_asked"] = totalAsked
+            }
 
             if (quizLog.comment.equals("Correct", ignoreCase = true)) {
-                val correctCount = (studentScores["correct_count"] as? Int ?: 0) + 1
-                studentScores["correct_count"] = correctCount
+                val correctCount = (studentScores["correct"] as? Int ?: 0) + 1
+                studentScores["correct"] = correctCount
             }
 
             val allScores = liveQuizScores.value?.toMutableMap() ?: mutableMapOf()
@@ -3356,35 +3387,53 @@ class SeatingChartViewModel @Inject constructor(
         }
     }
 
-    fun addHomeworkLogToSession(homeworkLog: HomeworkLog) {
+    /**
+     * BOLT: Bulk session logging for homework. Handles aggregated "Quick Mark" logs
+     * from the enhanced LiveHomeworkMarkDialog.
+     */
+    fun addHomeworkLogsToSession(logs: List<HomeworkLog>) {
         if (isSessionActive.value == true) {
             val currentLogs = sessionHomeworkLogs.value.orEmpty().toMutableList()
-            val existingLogIndex = currentLogs.indexOfFirst {
-                it.studentId == homeworkLog.studentId && it.assignmentName == homeworkLog.assignmentName
-            }
+            val allLiveScores = liveHomeworkScores.value?.toMutableMap() ?: mutableMapOf()
 
-            if (existingLogIndex != -1) {
-                currentLogs[existingLogIndex] = homeworkLog
-            } else {
+            logs.forEach { homeworkLog ->
+                // 1. Update session logs list (for persistence)
+                // We keep all logs in the session unless they are identical updates.
                 currentLogs.add(homeworkLog)
+
+                // 2. Update live scores map (for UI/Conditional Formatting)
+                val studentScores = allLiveScores[homeworkLog.studentId]?.toMutableMap() ?: mutableMapOf()
+
+                val marksData = HomeworkScoreEngine.parseMarksData(homeworkLog.marksData)
+                if (marksData.containsKey("selected_options")) {
+                    // "Select" mode aggregation
+                    studentScores["selected_options"] = marksData["selected_options"] ?: emptyList<String>()
+                } else if (homeworkLog.assignmentName == "Yes/No Update") {
+                    // "Yes/No" mode aggregation
+                    marksData.forEach { (key, value) ->
+                        studentScores[key] = value
+                    }
+                } else {
+                    // Individual assignment or Template
+                    studentScores[homeworkLog.assignmentName] = homeworkLog.status
+                }
+                allLiveScores[homeworkLog.studentId] = studentScores
             }
+
             sessionHomeworkLogs.postValue(currentLogs)
-
-            // Update live scores for immediate UI feedback
-            val studentScores = liveHomeworkScores.value?.get(homeworkLog.studentId)?.toMutableMap() ?: mutableMapOf()
-            studentScores[homeworkLog.assignmentName] = homeworkLog.status
-            val allScores = liveHomeworkScores.value?.toMutableMap() ?: mutableMapOf()
-            allScores[homeworkLog.studentId] = studentScores
-            liveHomeworkScores.postValue(allScores)
-
+            liveHomeworkScores.postValue(allLiveScores)
 
             Log.d(
                 "SeatingChartViewModel",
-                "Homework log added/updated in session for student_${homeworkLog.studentId.toString().hashCode()}."
+                "Added ${logs.size} homework log(s) to session."
             )
         } else {
-            addHomeworkLog(homeworkLog)
+            logs.forEach { addHomeworkLog(it) }
         }
+    }
+
+    fun addHomeworkLogToSession(homeworkLog: HomeworkLog) {
+        addHomeworkLogsToSession(listOf(homeworkLog))
     }
 
     private suspend fun executeCommand(command: Command) {


### PR DESCRIPTION
Ported enhanced live session marking logic for Homework and Quizzes from the Python desktop blueprint to the Android application. Key changes:
- `LiveHomeworkMarkDialog` now supports multi-assignment 'Yes/No' and multi-option 'Select' modes.
- `LiveQuizMarkDialog` includes real-time score display and a 'Skip' button.
- `SeatingChartViewModel` aggregates session marks into live score maps to drive UI feedback and conditional formatting.
- Student icons now display session-specific progress (e.g., 'Quiz: 3 of 5') during active sessions.
- Fixed several critical bugs identified during review, including compilation errors and key mismatches.

---
*PR created automatically by Jules for task [2940036711854005857](https://jules.google.com/task/2940036711854005857) started by @YMSeatt*