### PR TITLE
🛡️ Shield: Hardening File Permissions in FileLocker

### DIFF
--- a/app/src/main/java/com/example/myapplication/util/FileLocker.kt
+++ b/app/src/main/java/com/example/myapplication/util/FileLocker.kt
@@ -28,8 +28,8 @@ object FileLocker {
         }
 
         return try {
-            // Set readable for all, consistent with Python's 444 (r--r--r--)
-            file.setReadable(true, false)
+            // HARDEN: Restrict read access to owner-only (600/400) instead of world-readable (644/444)
+            file.setReadable(true, true)
             val success = file.setReadOnly()
             if (success) {
                 Log.i(TAG, "'${file.name}' has been locked (set to read-only).")
@@ -58,8 +58,8 @@ object FileLocker {
         }
 
         return try {
-            // Set readable for all, and writable for owner, consistent with Python's 644 (rw-r--r--)
-            file.setReadable(true, false)
+            // HARDEN: Restrict read access to owner-only instead of world-readable
+            file.setReadable(true, true)
             val success = file.setWritable(true, true)
             if (success) {
                 Log.i(TAG, "'${file.name}' has been unlocked (set to writable).")


### PR DESCRIPTION
🔓 *The Vulnerability:* The `FileLocker` utility was using `file.setReadable(true, false)`, which explicitly made sensitive classroom data files world-readable (Unix permission 444 or 644). This allowed any other application on the device to read exported students, behavior logs, and other PII.

🔐 *The Fix:* Hardened `FileLocker.kt` by changing the `ownerOnly` parameter to `true` in both `lock()` and `unlock()` methods. This ensures that files are only readable by the application itself (owner-only access).

📜 *Compliance:* This aligns with OWASP Masvs-Storage-1 (Data is not stored outside of the app container) and Google Play safety standards regarding the minimization of PII exposure.

---
*PR created automatically by Jules for task [14315204245577042828](https://jules.google.com/task/14315204245577042828) started by @YMSeatt*