### PR TITLE
🌉 Bridge: Port homework scoring Boolean parity from Python

### DIFF
--- a/app/src/main/java/com/example/myapplication/util/HomeworkScoreEngine.kt
+++ b/app/src/main/java/com/example/myapplication/util/HomeworkScoreEngine.kt
@@ -119,7 +119,11 @@ object HomeworkScoreEngine {
 
         // 1. Numeric accumulation from marksData
         marksData.values.forEach { value ->
-            val doubleVal = if (value is Number) value.toDouble() else value.toString().toDoubleOrNull()
+            val doubleVal = when (value) {
+                is Number -> value.toDouble()
+                is Boolean -> if (value) 1.0 else 0.0
+                else -> value.toString().toDoubleOrNull()
+            }
             doubleVal?.let { totalPoints += it }
         }
 
@@ -143,10 +147,15 @@ object HomeworkScoreEngine {
         // Python: for opt_name in selected_options: if opt_mark_type: total_points += opt_mark_type.default_points
         // In Android, selected options are often stored as keys in marksData with value 1.0 or similar.
         marksData.forEach { (key, value) ->
-            // If the value is a boolean true or a 1.0, and the key matches a metadata name,
+            // If the value is a boolean true/false or numeric, and the key matches a metadata name,
             // we might be double-counting if we already summed it as numeric.
             // But if it's NOT a number (e.g. "Done": "Yes"), we should handle it.
-            if (value !is Number && value.toString().toDoubleOrNull() == null) {
+            val isNumeric = when (value) {
+                is Number -> true
+                is Boolean -> true
+                else -> value.toString().toDoubleOrNull() != null
+            }
+            if (!isNumeric) {
                 // BOLT: O(1) lookup for metadata names
                 metadataMap[key.lowercase()]?.let {
                     totalPoints += it.defaultPoints

--- a/app/src/test/java/com/example/myapplication/util/HomeworkScoreEngineTest.kt
+++ b/app/src/test/java/com/example/myapplication/util/HomeworkScoreEngineTest.kt
@@ -96,4 +96,74 @@ class HomeworkScoreEngineTest {
         val score = HomeworkScoreEngine.calculateTotalPoints(log, metadata)
         assertEquals(0.0, score, 0.001)
     }
+
+    @Test
+    fun `calculateTotalPoints Python blueprint parity cases`() {
+        val testMetadata = listOf(
+            HomeworkMarkMetadata(id = 1, name = "Complete", defaultPoints = 10.0),
+            HomeworkMarkMetadata(id = 2, name = "Late", defaultPoints = 5.0),
+            HomeworkMarkMetadata(id = 3, name = "Bonus", defaultPoints = 2.0)
+        )
+
+        // Case 1: Yes status (mapping to Complete = 10.0) + Reading = 1.0 -> 11.0
+        val log1 = HomeworkLog(
+            studentId = 1,
+            assignmentName = "Math",
+            status = "Yes",
+            marksData = "{\"Reading\": 1.0}"
+        )
+        assertEquals(11.0, HomeworkScoreEngine.calculateTotalPoints(log1, testMetadata), 0.001)
+
+        // Case 2: Late status (5.0) + empty marks -> 5.0
+        val log2 = HomeworkLog(
+            studentId = 1,
+            assignmentName = "Math",
+            status = "Late",
+            marksData = "{}"
+        )
+        assertEquals(5.0, HomeworkScoreEngine.calculateTotalPoints(log2, testMetadata), 0.001)
+
+        // Case 3: No status + Bonus: "Yes" (maps to Bonus metadata = 2.0) + Math = 5.0 -> 7.0
+        val log3 = HomeworkLog(
+            studentId = 1,
+            assignmentName = "Math",
+            status = "No",
+            marksData = "{\"Bonus\": \"Yes\", \"Math\": 5.0}"
+        )
+        assertEquals(7.0, HomeworkScoreEngine.calculateTotalPoints(log3, testMetadata), 0.001)
+
+        // Case 4: Complete status (10.0) + Extra = 5.0 -> 15.0
+        val log4 = HomeworkLog(
+            studentId = 1,
+            assignmentName = "Math",
+            status = "Complete",
+            marksData = "{\"Extra\": 5.0}"
+        )
+        assertEquals(15.0, HomeworkScoreEngine.calculateTotalPoints(log4, testMetadata), 0.001)
+    }
+
+    @Test
+    fun `calculateTotalPoints Python boolean evaluation parity`() {
+        val testMetadata = listOf(
+            HomeworkMarkMetadata(id = 1, name = "Bonus", defaultPoints = 2.0)
+        )
+
+        // Booleans are numeric in Python (True = 1.0, False = 0.0).
+        // Under Python logic, {"Bonus": True} counts as numeric, adding 1.0 but NOT triggering status-like key mapping.
+        val logTrue = HomeworkLog(
+            studentId = 1,
+            assignmentName = "Math",
+            status = "No",
+            marksData = "{\"Bonus\": true}"
+        )
+        assertEquals(1.0, HomeworkScoreEngine.calculateTotalPoints(logTrue, testMetadata), 0.001)
+
+        val logFalse = HomeworkLog(
+            studentId = 1,
+            assignmentName = "Math",
+            status = "No",
+            marksData = "{\"Bonus\": false}"
+        )
+        assertEquals(0.0, HomeworkScoreEngine.calculateTotalPoints(logFalse, testMetadata), 0.001)
+    }
 }


### PR DESCRIPTION
This pull request aligns HomeworkScoreEngine.kt with Python's verify_homework_logic.py. It treats Boolean values in marksData as numeric (true -> 1.0, false -> 0.0) to emulate Python's boolean-to-float subclassing behavior, and ensures they are correctly classified to prevent triggering false status-based metadata matching. It also ports and adds the four Python verification tests and Boolean test cases to HomeworkScoreEngineTest.kt.

---
*PR created automatically by Jules for task [14482926590561306254](https://jules.google.com/task/14482926590561306254) started by @YMSeatt*