### PR TITLE
🛡️ Shield: [Security Hardening] in [Excel Import Utility]

### DIFF
--- a/app/src/main/java/com/example/myapplication/util/ExcelImportUtil.kt
+++ b/app/src/main/java/com/example/myapplication/util/ExcelImportUtil.kt
@@ -93,6 +93,11 @@ object ExcelImportUtil {
         try {
             val maxSizeBytes = 50 * 1024 * 1024L // 50MB limit
 
+            // HARDEN: Protect against Zip Bomb and XML Entity Expansion attacks by setting POI's ZipSecureFile limits
+            org.apache.poi.openxml4j.util.ZipSecureFile.setMinInflateRatio(0.01)
+            org.apache.poi.openxml4j.util.ZipSecureFile.setMaxEntrySize(maxSizeBytes)
+            org.apache.poi.openxml4j.util.ZipSecureFile.setMaxTextSize(maxSizeBytes)
+
             val inputStream: InputStream? = context.contentResolver.openInputStream(uri)
             inputStream.use { stream ->
                 if (stream == null) return@withContext Result.success(0)


### PR DESCRIPTION
### 🔓 The Vulnerability:
During bulk student roster ingestion via Excel files, Apache POI processes XML and zip structures. This can be exploited using Zip Bomb (zip recursion/high inflation ratios) or XML Entity Expansion attacks, which exhausts the Android device's resources (CPU and memory), leading to a Denial of Service (DoS) / application crash (OutOfMemoryError).

### 🔐 The Fix:
We explicitly configure Apache POI's `ZipSecureFile` security parameters right before spreadsheet reading begins:
- Set minimum inflate ratio to `0.01` (`setMinInflateRatio`).
- Set maximum zip entry size to 50MB (`setMaxEntrySize`), which matches our pre-existing file size limits.
- Set maximum XML text size limit to 50MB (`setMaxTextSize`).

### 📜 Compliance:
This aligns directly with OWASP Top 10 recommendations (A05:2021-Security Misconfiguration / XML External Entities & DoS protection) and Android Google Play safety standards for robust data handling.

---
*PR created automatically by Jules for task [11982715269676217906](https://jules.google.com/task/11982715269676217906) started by @YMSeatt*