### PR TITLE
Bridge: Port ChangeStudentStyleCommand from Python

### DIFF
--- a/.jules/bridge.md
+++ b/.jules/bridge.md
@@ -45,3 +45,7 @@ LaunchedEffect(autoLockEnabled, autoLockTimeoutMinutes, unlocked, lastActivityTi
 ## 2024-05-20 - Quiz Mark Initials Discrepancy
 **Discrepancy:** Python combines Behaviors and Quiz Mark Types in a single initials map (`behavior_initial_overrides`). Android split them into tabs but omitted Quiz Mark Types from the customization UI entirely.
 **Adaptation:** Unified Quiz Mark Types into the "Behaviors" tab of `ManageInitialsScreen.kt` while maintaining the separate "Quizzes" tab for Template-specific initials to provide superior organization while keeping functional parity.
+
+## 2026-03-12 - ChangeStudentStyleCommand Port & Schema Mapping
+**Discrepancy:** The Python prototype's `ChangeStudentStyleCommand` operates on a highly dynamic, mutable `style_overrides` dictionary. Android/Room structures enforce a strict relational database schema with individual dedicated column fields in the `Student` entity.
+**Adaptation:** Mapped the dynamic string-based property keys (e.g., `"customBackgroundColor"`, `"width"`) to their corresponding type-safe student entity fields using an internal helper function. Safely cast dynamic inputs (`Any?`) to specific types (`String?`, `Int?`) during entity copying, preserving strict multi-platform logical parity without compromising database integrity or thread-safe entity copies.

--- a/app/src/main/java/com/example/myapplication/commands/ChangeStudentStyleCommand.kt
+++ b/app/src/main/java/com/example/myapplication/commands/ChangeStudentStyleCommand.kt
@@ -1,0 +1,56 @@
+package com.example.myapplication.commands
+
+import com.example.myapplication.data.Student
+import com.example.myapplication.viewmodel.SeatingChartViewModel
+
+/**
+ * Command to update visual style overrides (e.g., color, font size) for a specific student.
+ * Bridges the dynamic dictionary styling model of Python to Android's strongly typed, schema-based model.
+ *
+ * @param viewModel The ViewModel to perform the database operations.
+ * @param studentId The ID of the student being styled.
+ * @param styleProperty The style property to update (e.g., "customBackgroundColor").
+ * @param oldValue The previous value of the style property.
+ * @param newValue The new value to apply.
+ */
+class ChangeStudentStyleCommand(
+    private val viewModel: SeatingChartViewModel,
+    private val studentId: Long,
+    private val styleProperty: String,
+    private val oldValue: Any?,
+    private val newValue: Any?
+) : Command {
+
+    override suspend fun execute() {
+        val student = viewModel.getStudentForEditing(studentId) ?: return
+        val updatedStudent = applyStyleProperty(student, styleProperty, newValue)
+        viewModel.internalUpdateStudent(updatedStudent)
+    }
+
+    override suspend fun undo() {
+        val student = viewModel.getStudentForEditing(studentId) ?: return
+        val updatedStudent = applyStyleProperty(student, styleProperty, oldValue)
+        viewModel.internalUpdateStudent(updatedStudent)
+    }
+
+    override fun getDescription(): String {
+        return "Style Change: $styleProperty for student ID $studentId"
+    }
+
+    private fun applyStyleProperty(student: Student, property: String, value: Any?): Student {
+        return when (property) {
+            "backgroundColor", "customBackgroundColor" -> student.copy(customBackgroundColor = value as? String)
+            "outlineColor", "customOutlineColor" -> student.copy(customOutlineColor = value as? String)
+            "textColor", "customTextColor" -> student.copy(customTextColor = value as? String)
+            "outlineThickness", "customOutlineThickness" -> student.copy(customOutlineThickness = value as? Int)
+            "cornerRadius", "customCornerRadius" -> student.copy(customCornerRadius = value as? Int)
+            "padding", "customPadding" -> student.copy(customPadding = value as? Int)
+            "fontFamily", "customFontFamily" -> student.copy(customFontFamily = value as? String)
+            "fontSize", "customFontSize" -> student.copy(customFontSize = value as? Int)
+            "fontColor", "customFontColor" -> student.copy(customFontColor = value as? String)
+            "width", "customWidth" -> student.copy(customWidth = value as? Int)
+            "height", "customHeight" -> student.copy(customHeight = value as? Int)
+            else -> throw IllegalArgumentException("Unknown style property: $property")
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/SeatingChartViewModel.kt
@@ -36,6 +36,7 @@ import com.example.myapplication.commands.MoveItemsCommand
 import com.example.myapplication.commands.ItemMove
 import com.example.myapplication.commands.ItemType
 import com.example.myapplication.commands.MoveStudentCommand
+import com.example.myapplication.commands.ChangeStudentStyleCommand
 import com.example.myapplication.commands.UpdateFurnitureCommand
 import com.example.myapplication.commands.UpdateStudentCommand
 import com.example.myapplication.data.AppDatabase
@@ -1387,6 +1388,19 @@ class SeatingChartViewModel @Inject constructor(
                 yPosition = resolvedY
             )
             val command = AddStudentCommand(this@SeatingChartViewModel, positionedStudent)
+            executeCommand(command)
+        }
+    }
+
+    fun changeStudentStyle(studentId: Long, property: String, oldValue: Any?, newValue: Any?) {
+        viewModelScope.launch {
+            val command = ChangeStudentStyleCommand(
+                this@SeatingChartViewModel,
+                studentId,
+                property,
+                oldValue,
+                newValue
+            )
             executeCommand(command)
         }
     }

--- a/app/src/test/java/com/example/myapplication/commands/ChangeStudentStyleCommandTest.kt
+++ b/app/src/test/java/com/example/myapplication/commands/ChangeStudentStyleCommandTest.kt
@@ -1,0 +1,99 @@
+package com.example.myapplication.commands
+
+import com.example.myapplication.data.Student
+import com.example.myapplication.viewmodel.SeatingChartViewModel
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+
+class ChangeStudentStyleCommandTest {
+
+    private val viewModel = mockk<SeatingChartViewModel>(relaxed = true)
+
+    @Test
+    fun `execute applies custom background color style and undo restores oldValue`() = runTest {
+        val studentId = 1L
+        val originalStudent = Student(id = studentId, firstName = "Alice", lastName = "Smith", customBackgroundColor = "#FFFFFF")
+
+        coEvery { viewModel.getStudentForEditing(studentId) } returns originalStudent
+
+        val command = ChangeStudentStyleCommand(
+            viewModel = viewModel,
+            studentId = studentId,
+            styleProperty = "customBackgroundColor",
+            oldValue = "#FFFFFF",
+            newValue = "#00FF00"
+        )
+
+        // Execute the style change
+        command.execute()
+
+        // Verify the student object was updated with the new background color
+        val expectedNewStudent = originalStudent.copy(customBackgroundColor = "#00FF00")
+        coVerify { viewModel.internalUpdateStudent(expectedNewStudent) }
+
+        // Execute undo
+        command.undo()
+
+        // Verify the student object was restored to original background color
+        coVerify { viewModel.internalUpdateStudent(originalStudent) }
+    }
+
+    @Test
+    fun `execute handles null and alternate style property names for dimensions`() = runTest {
+        val studentId = 2L
+        val originalStudent = Student(id = studentId, firstName = "Bob", lastName = "Jones", customWidth = 100, customHeight = 80)
+
+        coEvery { viewModel.getStudentForEditing(studentId) } returns originalStudent
+
+        val widthCommand = ChangeStudentStyleCommand(
+            viewModel = viewModel,
+            studentId = studentId,
+            styleProperty = "width",
+            oldValue = 100,
+            newValue = 150
+        )
+
+        widthCommand.execute()
+        val expectedWidthStudent = originalStudent.copy(customWidth = 150)
+        coVerify { viewModel.internalUpdateStudent(expectedWidthStudent) }
+
+        val heightCommand = ChangeStudentStyleCommand(
+            viewModel = viewModel,
+            studentId = studentId,
+            styleProperty = "height",
+            oldValue = 80,
+            newValue = null
+        )
+
+        heightCommand.execute()
+        val expectedHeightStudent = originalStudent.copy(customHeight = null)
+        coVerify { viewModel.internalUpdateStudent(expectedHeightStudent) }
+    }
+
+    @Test
+    fun `execute throws exception for unknown property name`() = runTest {
+        val studentId = 3L
+        val originalStudent = Student(id = studentId, firstName = "Charlie", lastName = "Brown")
+        coEvery { viewModel.getStudentForEditing(studentId) } returns originalStudent
+
+        val command = ChangeStudentStyleCommand(
+            viewModel = viewModel,
+            studentId = studentId,
+            styleProperty = "invalidProperty",
+            oldValue = null,
+            newValue = "someValue"
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                command.execute()
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/example/myapplication/util/HomeworkScoreEngineTest.kt
+++ b/app/src/test/java/com/example/myapplication/util/HomeworkScoreEngineTest.kt
@@ -1,10 +1,16 @@
 package com.example.myapplication.util
 
+import android.app.Application
 import com.example.myapplication.data.HomeworkLog
 import com.example.myapplication.data.HomeworkMarkMetadata
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
 class HomeworkScoreEngineTest {
 
     private val metadata = listOf(


### PR DESCRIPTION
🐍 Source: Python/commands.py (lines 889-938)
🤖 Implementation:
- Added ChangeStudentStyleCommand.kt under com.example.myapplication.commands
- Added changeStudentStyle(...) inside SeatingChartViewModel.kt
- Aligned HomeworkScoreEngineTest.kt unit test runner with Robolectric to support LruCache
- Added ChangeStudentStyleCommandTest.kt under com.example.myapplication.commands
🔄 Mapping Strategy: Mapped the dynamic dictionary key-value style_overrides properties of the Python command to safe-casted individual column/property mutations on the Room-database Student entity in Kotlin, ensuring thread-safe database updates and absolute platform compliance.
🧪 Verification: Passed custom JVM unit tests (ChangeStudentStyleCommandTest) and all other relevant unit tests.

---
*PR created automatically by Jules for task [171069135338825444](https://jules.google.com/task/171069135338825444) started by @YMSeatt*